### PR TITLE
fix: parse JSON scopes in auth middleware (#35)

### DIFF
--- a/packages/control/src/__tests__/integration/auth.test.ts
+++ b/packages/control/src/__tests__/integration/auth.test.ts
@@ -45,4 +45,69 @@ describe('Auth', () => {
     const res = await fetch(`${baseUrl}/api/health`);
     expect(res.status).toBe(200);
   });
+
+  it('allows scoped token with tasks:write', async () => {
+    // Create a scoped token with tasks:write scope
+    const { createHash, randomUUID } = await import('node:crypto');
+    const { authTokenRepo } = await import('../../repositories/auth-token-repo.js');
+
+    const scopedToken = 'test-scoped-token-' + Date.now();
+    const tokenHash = createHash('sha256').update(scopedToken).digest('hex');
+    
+    // Create token with tasks:write scope (stored as JSON string in DB)
+    authTokenRepo.create({
+      id: randomUUID(),
+      tokenHash,
+      userId: null, // instance token, not user token
+      agentName: 'test-instance',
+      label: 'test-instance-token',
+      scopes: ['tasks:write'], // This will be JSON.stringify'd
+    });
+
+    // Should succeed with tasks:write scope
+    const res = await fetch(`${baseUrl}/api/tasks/test-task-123/result`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${scopedToken}`, 
+        'Content-Type': 'application/json' 
+      },
+      body: JSON.stringify({ result: 'test result' }),
+    });
+
+    // Should NOT be 403 (insufficient permissions)
+    expect(res.status).not.toBe(403);
+  });
+
+  it('rejects scoped token without required scope', async () => {
+    // Create a scoped token without tasks:write
+    const { createHash, randomUUID } = await import('node:crypto');
+    const { authTokenRepo } = await import('../../repositories/auth-token-repo.js');
+
+    const scopedToken = 'test-scoped-token-read-' + Date.now();
+    const tokenHash = createHash('sha256').update(scopedToken).digest('hex');
+    
+    authTokenRepo.create({
+      id: randomUUID(),
+      tokenHash,
+      userId: null,
+      agentName: 'test-instance-read',
+      label: 'test-instance-read-token',
+      scopes: ['tasks:read'], // Only read, not write
+    });
+
+    // Should fail with tasks:write scope required
+    const res = await fetch(`${baseUrl}/api/tasks/test-task-456/result`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${scopedToken}`, 
+        'Content-Type': 'application/json' 
+      },
+      body: JSON.stringify({ result: 'test result' }),
+    });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe('Insufficient permissions');
+    expect(json.missing).toContain('tasks:write');
+  });
 });

--- a/packages/control/src/middleware/auth.ts
+++ b/packages/control/src/middleware/auth.ts
@@ -11,6 +11,7 @@ export interface Caller {
   type: 'human' | 'agent' | 'operator' | 'system';
   agentName?: string;
   tokenId?: string;
+  scopes?: string[];
 }
 
 declare global {
@@ -115,6 +116,20 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
         // Update last_used_at
         authTokenRepo.updateLastUsed(row.tokenId);
 
+        // Parse scopes from JSON string (handles null, empty string, already-parsed-array)
+        let parsedScopes: string[] | undefined;
+        if (row.scopes) {
+          try {
+            if (typeof row.scopes === 'string') {
+              parsedScopes = JSON.parse(row.scopes);
+            } else if (Array.isArray(row.scopes)) {
+              parsedScopes = row.scopes;
+            }
+          } catch {
+            // If parsing fails, leave undefined
+          }
+        }
+
         req.caller = {
           id: row.uid || row.tokenId,
           name: row.name || row.agentName || 'unknown',
@@ -123,6 +138,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
           type: row.agentName ? 'agent' : ((row.type || 'human') as Caller['type']),
           agentName: row.agentName || undefined,
           tokenId: row.tokenId,
+          scopes: parsedScopes,
         };
         next();
         return;

--- a/packages/control/src/middleware/scopes.ts
+++ b/packages/control/src/middleware/scopes.ts
@@ -49,7 +49,12 @@ export function requireScope(...scopes: Scope[]): any {
       res.status(401).json({ error: 'Authentication required' });
       return;
     }
-    const userScopes = getScopesForRole(caller.role);
+    
+    // Use token-specific scopes if present, otherwise fall back to role-based scopes
+    const userScopes = caller.scopes && Array.isArray(caller.scopes) && caller.scopes.length > 0
+      ? caller.scopes
+      : getScopesForRole(caller.role);
+    
     const missing = scopes.filter(s => !userScopes.includes(s));
     if (missing.length > 0) {
       res.status(403).json({ error: 'Insufficient permissions', required: scopes, missing });


### PR DESCRIPTION
Fixes #35

## Problem
Instance-scoped tokens with `tasks:write` scope were getting 403 errors when calling `POST /api/tasks/:id/result`. The scopes column stores a JSON string like `["tasks:write","agents:read"]` in SQLite, but the auth middleware wasn't parsing it.

## Solution
1. Updated `auth.ts` to parse the JSON scopes string when authenticating with a token
2. Updated `scopes.ts` to check token-specific scopes if present, falling back to role-based scopes
3. Added `Caller.scopes` field to pass parsed scopes through the request context
4. Added integration tests for scoped token authentication

## Changes
- `packages/control/src/middleware/auth.ts`: Parse JSON scopes, handle edge cases (null, empty string, already-array)
- `packages/control/src/middleware/scopes.ts`: Check token scopes before falling back to role scopes
- `packages/control/src/__tests__/integration/auth.test.ts`: Tests for scoped token success and rejection cases