### PR TITLE
feat: scope-filtered tool definitions (#31)

### DIFF
--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -49,20 +49,24 @@ async function start() {
 
   // ── Meta: tool definitions for auto-discovery ───────────────────
   const { getToolDefs } = await import('./utils/tool-registry.js');
-  app.get('/api/meta/tools', (req, res) => {
+  const { optionalAuthMiddleware } = await import('./middleware/auth.js');
+  
+  app.get('/api/meta/tools', optionalAuthMiddleware, (req, res) => {
     const allTools = getToolDefs();
-    const agentName = req.headers['x-agent-name'] as string;
-
-    // If no agent header, return all tools (e.g., operator/control plugin)
-    if (!agentName) return res.json(allTools);
-
-    // Look up agent's role
-    const agents = agentsRepo.getAll();
-    const agent = agents.find(a => a.name === agentName);
-    if (!agent) return res.json(allTools); // Unknown agent, return all
-
-    // All tools available — tool filtering via allowedTools was removed (#598)
-    res.json(allTools);
+    
+    // Get caller's scopes from auth middleware (optional - may be undefined)
+    const callerScopes: string[] = req.caller?.scopes ?? [];
+    
+    // No scopes = return all (backward compat: unauthenticated or operator without scope restriction)
+    // Wildcard = return all
+    if (callerScopes.length === 0 || callerScopes.includes('*')) {
+      return res.json(allTools);
+    }
+    
+    // Filter tools to only those the caller has scope for
+    // Tools without a scope field are accessible to everyone
+    const filtered = allTools.filter(t => !t.scope || callerScopes.includes(t.scope));
+    res.json(filtered);
   });
 
   // ── Production: serve UI static files ─────────────────────────────

--- a/packages/control/src/middleware/auth.ts
+++ b/packages/control/src/middleware/auth.ts
@@ -150,3 +150,85 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
 
   res.status(401).json({ error: 'Missing or invalid Authorization header' });
 }
+
+/**
+ * Optional auth middleware - runs auth logic but doesn't reject on failure.
+ * Used for endpoints that work both authenticated (with filtering) and unauthenticated.
+ */
+export function optionalAuthMiddleware(req: Request, _res: Response, next: NextFunction): void {
+  // Extract token from header or query param
+  const header = req.headers.authorization;
+  const queryToken = req.query.token as string | undefined;
+  const token = header?.startsWith('Bearer ') ? header.slice(7) : queryToken;
+
+  try {
+    // 1. Check session cookie
+    const sessionToken = req.cookies?.armada_session;
+    if (sessionToken) {
+      const sessionHash = hashToken(sessionToken);
+      const session = sessionRepo.findByHash(sessionHash);
+
+      if (session && (!session.expiresAt || new Date(session.expiresAt) > new Date())) {
+        req.caller = {
+          id: session.userId,
+          name: session.name,
+          displayName: session.displayName || session.name,
+          role: session.role || 'viewer',
+          type: (session.type || 'human') as Caller['type'],
+        };
+        next();
+        return;
+      }
+    }
+
+    // 2. Check per-user/agent tokens
+    if (token) {
+      const hash = hashToken(token);
+      const row = authTokenRepo.findByHash(hash);
+
+      if (row) {
+        // Check expiry
+        if (row.expiresAt && new Date(row.expiresAt) < new Date()) {
+          // Expired - continue without setting caller
+          next();
+          return;
+        }
+
+        // Update last_used_at
+        authTokenRepo.updateLastUsed(row.tokenId);
+
+        // Parse scopes
+        let parsedScopes: string[] | undefined;
+        if (row.scopes) {
+          try {
+            if (typeof row.scopes === 'string') {
+              parsedScopes = JSON.parse(row.scopes);
+            } else if (Array.isArray(row.scopes)) {
+              parsedScopes = row.scopes;
+            }
+          } catch {
+            // Parsing failed - leave undefined
+          }
+        }
+
+        req.caller = {
+          id: row.uid || row.tokenId,
+          name: row.name || row.agentName || 'unknown',
+          displayName: row.displayName || row.name || row.agentName || 'Unknown',
+          role: row.role || 'agent',
+          type: row.agentName ? 'agent' : ((row.type || 'human') as Caller['type']),
+          agentName: row.agentName || undefined,
+          tokenId: row.tokenId,
+          scopes: parsedScopes,
+        };
+        next();
+        return;
+      }
+    }
+  } catch (err: any) {
+    console.warn('[auth] Optional auth check failed:', err.message);
+  }
+
+  // No auth found - continue without caller (unauthenticated)
+  next();
+}

--- a/packages/control/src/routes/agents.ts
+++ b/packages/control/src/routes/agents.ts
@@ -44,6 +44,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
       { name: 'templateId', type: 'string', description: 'Template ID to spawn from', required: true },
       { name: 'name', type: 'string', description: 'Agent name (lowercase, alphanumeric, hyphens)', required: true },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -54,6 +55,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
       { name: 'target', type: 'string', description: 'Agent name to redeploy, or "all" for every agent', required: true },
     ],
     supportsAll: true,
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -63,6 +65,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
     parameters: [
       { name: 'target', type: 'string', description: 'Agent name to destroy', required: true },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -86,6 +89,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
       { name: 'memoryMb', type: 'number', description: 'Memory usage in MB' },
       { name: 'uptimeMs', type: 'number', description: 'Agent uptime in milliseconds' },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -96,6 +100,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
       { name: 'name', type: 'string', description: 'Agent name to nudge', required: true },
       { name: 'message', type: 'string', description: 'Custom nudge message (optional)' },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -105,6 +110,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
     parameters: [
       { name: 'name', type: 'string', description: 'Agent name', required: true },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -114,6 +120,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
     parameters: [
       { name: 'name', type: 'string', description: 'Agent name', required: true },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({
@@ -125,6 +132,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
       { name: 'timeoutMs', type: 'number', description: 'Drain timeout in ms (default 60000)' },
       { name: 'reason', type: 'string', description: 'Maintenance reason (logged in activity)' },
     ],
+    scope: 'agents:write',
   });
 
   registerToolDef({

--- a/packages/control/src/routes/audit.ts
+++ b/packages/control/src/routes/audit.ts
@@ -17,6 +17,7 @@ registerToolDef({
     { name: 'limit', type: 'number', description: 'Max entries to return (default 50, max 200)' },
     { name: 'offset', type: 'number', description: 'Offset for pagination' },
   ],
+  scope: 'audit:read',
 });
 
 const router = Router();

--- a/packages/control/src/routes/config.ts
+++ b/packages/control/src/routes/config.ts
@@ -6,12 +6,14 @@ registerToolDef({
   name: 'armada_config_status',
   description: 'Get the current config version, stale instances, and pending restarts.',
   method: 'GET', path: '/api/config/status', parameters: [],
+    scope: 'system:read',
 });
 
 registerToolDef({
   name: 'armada_config_snapshot',
   description: 'Take a snapshot of the current config state (providers, models, plugins, template models).',
   method: 'GET', path: '/api/config/snapshot', parameters: [],
+    scope: 'system:read',
 });
 
 const router = Router();

--- a/packages/control/src/routes/credentials.ts
+++ b/packages/control/src/routes/credentials.ts
@@ -104,6 +104,7 @@ export function createCredentialRoutes(nodeManager: NodeManager): Router {
     parameters: [
       { name: 'name', type: 'string', description: 'Agent name', required: true },
     ],
+    scope: 'agents:write',
   });
 
   // ── GET /api/agents/:name/credentials ─────────────────────────────

--- a/packages/control/src/routes/hierarchy.ts
+++ b/packages/control/src/routes/hierarchy.ts
@@ -19,6 +19,7 @@ registerToolDef({
   description: 'Update the task routing rules. Each role maps to an array of roles it can assign tasks to.',
   method: 'PUT', path: '/api/hierarchy',
   parameters: [],
+  scope: 'system:write',
 });
 
 registerToolDef({
@@ -32,6 +33,7 @@ registerToolDef({
     { name: 'tier', type: 'number', description: 'Tier: 0=top, 1=middle, 2=leaf' },
     { name: 'icon', type: 'string', description: 'Emoji or icon identifier' },
   ],
+  scope: 'system:write',
 });
 
 registerToolDef({
@@ -41,6 +43,7 @@ registerToolDef({
   parameters: [
     { name: 'role', type: 'string', description: 'Role name (path param)', required: true },
   ],
+  scope: 'system:write',
 });
 
 export interface HierarchyRules {

--- a/packages/control/src/routes/instances.ts
+++ b/packages/control/src/routes/instances.ts
@@ -23,6 +23,7 @@ registerToolDef({
   description: 'List all armada instances. Shows instance name, node, status, and agent count.',
   method: 'GET', path: '/api/instances',
   parameters: [],
+    scope: 'instances:read',
 });
 
 registerToolDef({
@@ -32,6 +33,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Instance ID or name', required: true },
   ],
+    scope: 'instances:read',
 });
 
 registerToolDef({
@@ -48,6 +50,7 @@ registerToolDef({
     { name: 'memory', type: 'string', description: 'Container memory limit (e.g. 2g, 512m). Default: 2g' },
     { name: 'cpus', type: 'string', description: 'Container CPU limit (e.g. 1, 0.5). Default: 1' },
   ],
+    scope: 'instances:write',
 });
 
 registerToolDef({
@@ -64,6 +67,7 @@ registerToolDef({
     { name: 'status', type: 'string', description: 'Instance status' },
     { name: 'statusMessage', type: 'string', description: 'Status message' },
   ],
+    scope: 'instances:write',
 });
 
 registerToolDef({
@@ -73,6 +77,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Instance ID to destroy', required: true },
   ],
+    scope: 'instances:write',
 });
 
 registerToolDef({
@@ -82,6 +87,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Instance ID', required: true },
   ],
+    scope: 'instances:read',
 });
 
 // ── Routes ──────────────────────────────────────────────────────────

--- a/packages/control/src/routes/integrations.ts
+++ b/packages/control/src/routes/integrations.ts
@@ -18,6 +18,7 @@ registerToolDef({
   method: 'GET',
   path: '/api/integrations',
   parameters: [],
+    scope: 'integrations:read',
 });
 
 registerToolDef({
@@ -32,6 +33,7 @@ registerToolDef({
     { name: 'authConfig', type: 'string', description: 'Auth config JSON', required: true },
     { name: 'capabilities', type: 'string', description: 'JSON array of capabilities (issues, vcs)', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -42,6 +44,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Integration ID', required: true },
   ],
+    scope: 'integrations:read',
 });
 
 registerToolDef({
@@ -57,6 +60,7 @@ registerToolDef({
     { name: 'status', type: 'string', description: 'Status (active, error, expired)' },
     { name: 'statusMessage', type: 'string', description: 'Status message' },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -67,6 +71,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Integration ID', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -77,6 +82,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Integration ID', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -87,6 +93,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Integration ID', required: true },
   ],
+    scope: 'integrations:read',
 });
 
 registerToolDef({
@@ -97,6 +104,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Integration ID', required: true },
   ],
+    scope: 'integrations:read',
 });
 
 registerToolDef({
@@ -107,6 +115,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'integrations:read',
 });
 
 registerToolDef({
@@ -120,6 +129,7 @@ registerToolDef({
     { name: 'capability', type: 'string', description: 'Capability (issues or vcs)', required: true },
     { name: 'config', type: 'string', description: 'Config JSON (filters, repos, etc.)' },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -133,6 +143,7 @@ registerToolDef({
     { name: 'config', type: 'string', description: 'Config JSON' },
     { name: 'enabled', type: 'boolean', description: 'Enabled flag' },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -144,6 +155,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Project ID', required: true },
     { name: 'piId', type: 'string', description: 'Project integration ID', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 registerToolDef({
@@ -155,6 +167,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Project ID', required: true },
     { name: 'piId', type: 'string', description: 'Project integration ID', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 // ── Routes ──────────────────────────────────────────────────────────

--- a/packages/control/src/routes/models.ts
+++ b/packages/control/src/routes/models.ts
@@ -20,6 +20,7 @@ registerToolDef({
   description: 'List all models in the armada model registry.',
   method: 'GET', path: '/api/models',
   parameters: [],
+    scope: 'models:read',
 });
 
 registerToolDef({
@@ -29,6 +30,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Model ID', required: true },
   ],
+    scope: 'models:read',
 });
 
 registerToolDef({
@@ -45,6 +47,7 @@ registerToolDef({
     { name: 'maxTokens', type: 'number', description: 'Max tokens' },
     { name: 'costTier', type: 'string', description: 'Cost tier: cheap, standard, premium' },
   ],
+    scope: 'models:write',
 });
 
 registerToolDef({
@@ -62,6 +65,7 @@ registerToolDef({
     { name: 'maxTokens', type: 'number', description: 'Max tokens' },
     { name: 'costTier', type: 'string', description: 'Cost tier' },
   ],
+    scope: 'models:write',
 });
 
 registerToolDef({
@@ -71,6 +75,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Model ID to delete', required: true },
   ],
+    scope: 'models:write',
 });
 
 // GET /api/models

--- a/packages/control/src/routes/nodes.ts
+++ b/packages/control/src/routes/nodes.ts
@@ -16,6 +16,7 @@ registerToolDef({
   description: 'List all armada nodes (Docker hosts). Shows node name, URL, status, and agent count.',
   method: 'GET', path: '/api/nodes',
   parameters: [],
+    scope: 'nodes:read',
 });
 
 registerToolDef({
@@ -25,6 +26,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Node ID', required: true },
   ],
+    scope: 'nodes:read',
 });
 
 registerToolDef({
@@ -34,6 +36,7 @@ registerToolDef({
   parameters: [
     { name: 'hostname', type: 'string', description: 'Node hostname label', required: false },
   ],
+    scope: 'nodes:write',
 });
 
 registerToolDef({
@@ -44,6 +47,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Node ID', required: true },
     { name: 'hostname', type: 'string', description: 'Node hostname label' },
   ],
+    scope: 'nodes:write',
 });
 
 registerToolDef({
@@ -53,6 +57,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Node ID to remove', required: true },
   ],
+    scope: 'nodes:write',
 });
 
 registerToolDef({
@@ -62,6 +67,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Node ID to test', required: true },
   ],
+    scope: 'nodes:write',
 });
 
 registerToolDef({
@@ -71,6 +77,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Node ID', required: true },
   ],
+    scope: 'nodes:read',
 });
 
 registerToolDef({
@@ -80,6 +87,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Node ID', required: true },
   ],
+    scope: 'nodes:read',
 });
 
 export function createNodeRoutes(nodeManager: NodeManager): Router {

--- a/packages/control/src/routes/notification-channels.ts
+++ b/packages/control/src/routes/notification-channels.ts
@@ -26,6 +26,7 @@ registerToolDef({
     { name: 'enabled', type: 'boolean', description: 'Whether the channel is enabled', required: false },
     { name: 'config', type: 'string', description: 'Channel-specific config as JSON (e.g. { "token": "...", "chat_id": "..." } for Telegram, { "webhook_url": "..." } for Slack/Discord)', required: true },
   ],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -39,6 +40,7 @@ registerToolDef({
     { name: 'enabled', type: 'boolean', description: 'Enable or disable', required: false },
     { name: 'config', type: 'string', description: 'Channel-specific config as JSON', required: false },
   ],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -49,6 +51,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Channel ID', required: true },
   ],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -59,6 +62,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Channel ID', required: true },
   ],
+    scope: 'system:write',
 });
 
 // ── Router ────────────────────────────────────────────────────────────

--- a/packages/control/src/routes/operations.ts
+++ b/packages/control/src/routes/operations.ts
@@ -97,6 +97,7 @@ registerToolDef({
   parameters: [
     { name: 'status', type: 'string', description: 'Filter by status: running, completed, failed' },
   ],
+    scope: 'system:read',
 });
 
 registerToolDef({
@@ -107,6 +108,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', required: true, description: 'Operation ID' },
   ],
+    scope: 'system:read',
 });
 
 export { router as operationsRoutes };

--- a/packages/control/src/routes/plugin-library.ts
+++ b/packages/control/src/routes/plugin-library.ts
@@ -33,6 +33,7 @@ registerToolDef({
     { name: 'version', type: 'string', description: 'Version', required: false },
     { name: 'description', type: 'string', description: 'Description of the plugin', required: false },
   ],
+    scope: 'plugins:write',
 });
 
 registerToolDef({
@@ -47,6 +48,7 @@ registerToolDef({
     { name: 'version', type: 'string', description: 'Version', required: false },
     { name: 'description', type: 'string', description: 'Description', required: false },
   ],
+    scope: 'plugins:write',
 });
 
 registerToolDef({
@@ -56,6 +58,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Plugin ID', required: true },
   ],
+    scope: 'plugins:write',
 });
 
 registerToolDef({
@@ -74,6 +77,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Plugin ID', required: true },
   ],
+    scope: 'plugins:write',
 });
 
 registerToolDef({
@@ -83,6 +87,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Plugin ID', required: true },
   ],
+    scope: 'plugins:write',
 });
 
 // ── Routes ──────────────────────────────────────────────────────────

--- a/packages/control/src/routes/plugins.ts
+++ b/packages/control/src/routes/plugins.ts
@@ -23,6 +23,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Plugin name to update', required: true },
   ],
+  scope: 'plugins:write',
 });
 
 registerToolDef({
@@ -30,6 +31,7 @@ registerToolDef({
   description: 'Update all plugins in the armada shared plugins directory.',
   method: 'POST', path: '/api/plugins/update-all',
   parameters: [],
+  scope: 'plugins:write',
 });
 
 const PLUGINS_PATH = process.env.ARMADA_PLUGINS_PATH || '/data/armada/plugins';

--- a/packages/control/src/routes/projects.ts
+++ b/packages/control/src/routes/projects.ts
@@ -38,6 +38,7 @@ registerToolDef({
   parameters: [
     { name: 'includeArchived', type: 'boolean', description: 'Include archived projects (default: false)' },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -48,6 +49,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -63,6 +65,7 @@ registerToolDef({
     { name: 'icon', type: 'string', description: 'Project icon (emoji)' },
     { name: 'repositories', type: 'string', description: 'JSON array of {url, defaultBranch?, cloneDir?} repository objects' },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -79,6 +82,7 @@ registerToolDef({
     { name: 'icon', type: 'string', description: 'Project icon (emoji)' },
     { name: 'repositories', type: 'string', description: 'JSON array of {url, defaultBranch?, cloneDir?} repository objects' },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -89,6 +93,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -99,6 +104,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -109,6 +115,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -119,6 +126,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -129,6 +137,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID or name', required: true },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -139,6 +148,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID', required: true },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -149,6 +159,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID or name', required: true },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -159,6 +170,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID or name', required: true },
   ],
+    scope: 'projects:read',
 });
 
 registerToolDef({
@@ -170,6 +182,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Task ID', required: true },
     { name: 'column', type: 'string', description: 'Target board column', required: true },
   ],
+    scope: 'projects:write',
 });
 
 registerToolDef({
@@ -180,6 +193,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Project ID or name', required: true },
   ],
+    scope: 'projects:read',
 });
 
 // ── Routes ───────────────────────────────────────────────────────────

--- a/packages/control/src/routes/providers.ts
+++ b/packages/control/src/routes/providers.ts
@@ -31,6 +31,7 @@ registerToolDef({
     { name: 'baseUrl', type: 'string', description: 'Custom base URL', required: false },
     { name: 'enabled', type: 'boolean', description: 'Enable/disable provider', required: false },
   ],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -45,6 +46,7 @@ registerToolDef({
   description: 'Sync discovered models into the model registry from a provider.',
   method: 'POST', path: '/api/providers/:id/sync',
   parameters: [{ name: 'id', type: 'string', description: 'Provider ID', required: true }],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -65,6 +67,7 @@ registerToolDef({
     { name: 'isDefault', type: 'boolean', description: 'Set as default', required: false },
     { name: 'priority', type: 'number', description: 'Priority (lower = preferred)', required: false },
   ],
+    scope: 'system:write',
 });
 
 const router = Router();

--- a/packages/control/src/routes/proxy-prs.ts
+++ b/packages/control/src/routes/proxy-prs.ts
@@ -86,6 +86,7 @@ registerToolDef({
   parameters: [
     { name: 'project', type: 'string', description: 'Project ID or name', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/repos', async (req, res, next) => {
@@ -144,6 +145,7 @@ registerToolDef({
     { name: 'labels', type: 'string', description: 'Comma-separated label filter' },
     { name: 'cursor', type: 'string', description: 'Pagination cursor from previous response' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/list', async (req, res, next) => {
@@ -204,6 +206,7 @@ registerToolDef({
     { name: 'repo', type: 'string', description: 'Repository full name (owner/repo)', required: true },
     { name: 'number', type: 'number', description: 'PR number', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/get', async (req, res, next) => {
@@ -240,6 +243,7 @@ registerToolDef({
     { name: 'repo', type: 'string', description: 'Repository full name (owner/repo)', required: true },
     { name: 'number', type: 'number', description: 'PR number', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/reviews', async (req, res, next) => {
@@ -279,6 +283,7 @@ registerToolDef({
     { name: 'path', type: 'string', description: 'File path for inline review comment' },
     { name: 'line', type: 'number', description: 'Line number for inline comment' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/comment', requireScope('integrations:write'), async (req, res, next) => {
@@ -321,6 +326,7 @@ registerToolDef({
     { name: 'draft', type: 'boolean', description: 'Create as draft PR (default: false)' },
     { name: 'labels', type: 'string', description: 'JSON array of label names' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/create', requireScope('integrations:write'), async (req, res, next) => {
@@ -375,6 +381,7 @@ registerToolDef({
     { name: 'commitTitle', type: 'string', description: 'Custom merge commit title' },
     { name: 'commitMessage', type: 'string', description: 'Custom merge commit message' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/merge', requireScope('integrations:write'), async (req, res, next) => {
@@ -417,6 +424,7 @@ registerToolDef({
     { name: 'labels', type: 'string', description: 'JSON array of label names (replaces all)' },
     { name: 'assignees', type: 'string', description: 'JSON array of assignee usernames' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/update', requireScope('integrations:write'), async (req, res, next) => {

--- a/packages/control/src/routes/proxy.ts
+++ b/packages/control/src/routes/proxy.ts
@@ -72,6 +72,7 @@ registerToolDef({
     { name: 'types', type: 'string', description: 'Comma-separated issue type filter' },
     { name: 'cursor', type: 'string', description: 'Pagination cursor from previous response' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/list', async (req, res, next) => {
@@ -115,6 +116,7 @@ registerToolDef({
     { name: 'project', type: 'string', description: 'Project ID or name', required: true },
     { name: 'issueKey', type: 'string', description: 'Issue key (e.g., FIX-123, owner/repo#45)', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/get', async (req, res, next) => {
@@ -150,6 +152,7 @@ registerToolDef({
     { name: 'issueKey', type: 'string', description: 'Issue key', required: true },
     { name: 'comment', type: 'string', description: 'Comment text', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/comment', requireScope('integrations:write'), async (req, res, next) => {
@@ -185,6 +188,7 @@ registerToolDef({
     { name: 'issueKey', type: 'string', description: 'Issue key', required: true },
     { name: 'status', type: 'string', description: 'Target status', required: true },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/transition', requireScope('integrations:write'), async (req, res, next) => {
@@ -220,6 +224,7 @@ registerToolDef({
     { name: 'query', type: 'string', description: 'Search query (JQL for Jira, query string for GitHub)', required: true },
     { name: 'cursor', type: 'string', description: 'Pagination cursor' },
   ],
+    scope: 'integrations:write',
 });
 
 router.post('/search', async (req, res, next) => {

--- a/packages/control/src/routes/settings.ts
+++ b/packages/control/src/routes/settings.ts
@@ -9,6 +9,7 @@ registerToolDef({
   name: 'armada_settings_get',
   description: 'Get all armada settings (version, retention, avatar generation, sync interval).',
   method: 'GET', path: '/api/settings', parameters: [],
+    scope: 'system:read',
 });
 
 registerToolDef({
@@ -19,6 +20,7 @@ registerToolDef({
     { name: 'key', type: 'string', description: 'Setting key (armada_openclaw_version, workspace_retention_days, ai_avatar_generation, github_sync_interval_minutes, avatar_provider_id, avatar_model_id)', required: true },
     { name: 'value', type: 'string', description: 'Setting value', required: true },
   ],
+    scope: 'system:write',
 });
 
 const router = Router();

--- a/packages/control/src/routes/skill-library.ts
+++ b/packages/control/src/routes/skill-library.ts
@@ -33,6 +33,7 @@ registerToolDef({
     { name: 'version', type: 'string', description: 'Version', required: false },
     { name: 'description', type: 'string', description: 'Description of the skill', required: false },
   ],
+    scope: 'skills:write',
 });
 
 registerToolDef({
@@ -47,6 +48,7 @@ registerToolDef({
     { name: 'version', type: 'string', description: 'Version', required: false },
     { name: 'description', type: 'string', description: 'Description', required: false },
   ],
+    scope: 'skills:write',
 });
 
 registerToolDef({
@@ -56,6 +58,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Skill ID', required: true },
   ],
+    scope: 'skills:write',
 });
 
 registerToolDef({
@@ -74,6 +77,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Skill ID', required: true },
   ],
+    scope: 'skills:write',
 });
 
 // ── Routes ──────────────────────────────────────────────────────────

--- a/packages/control/src/routes/skills.ts
+++ b/packages/control/src/routes/skills.ts
@@ -29,6 +29,7 @@ registerToolDef({
     { name: 'name', type: 'string', description: 'Agent name', required: true },
     { name: 'skill', type: 'string', description: 'Skill name to install', required: true },
   ],
+  scope: 'skills:write',
 });
 
 registerToolDef({
@@ -39,6 +40,7 @@ registerToolDef({
     { name: 'name', type: 'string', description: 'Agent name', required: true },
     { name: 'skill', type: 'string', description: 'Skill name to remove', required: true },
   ],
+  scope: 'skills:write',
 });
 
 registerToolDef({
@@ -48,6 +50,7 @@ registerToolDef({
   parameters: [
     { name: 'name', type: 'string', description: 'Agent name', required: true },
   ],
+  scope: 'skills:write',
 });
 
 registerToolDef({
@@ -57,6 +60,7 @@ registerToolDef({
   parameters: [
     { name: 'skill', type: 'string', description: 'Skill name or clawhub package to install', required: true },
   ],
+  scope: 'skills:write',
 });
 
 registerToolDef({
@@ -66,6 +70,7 @@ registerToolDef({
   parameters: [
     { name: 'skill', type: 'string', description: 'Skill name to update', required: true },
   ],
+  scope: 'skills:write',
 });
 
 export function createSkillRoutes(nodeManager: NodeManager): Router {

--- a/packages/control/src/routes/tasks.ts
+++ b/packages/control/src/routes/tasks.ts
@@ -485,6 +485,7 @@ registerToolDef({
     { name: 'type', type: 'string', description: 'Task type for routing and display', enum: ['code_change', 'review', 'research', 'deployment', 'test', 'generic'] },
     { name: 'payload', type: 'string', description: 'Structured task payload as JSON (type-specific metadata)' },
   ],
+  scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -497,6 +498,7 @@ registerToolDef({
     { name: 'status', type: 'string', description: 'New status', enum: ['pending', 'running', 'completed', 'failed', 'blocked'] },
     { name: 'result', type: 'string', description: 'Task result text' },
   ],
+  scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -507,6 +509,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Task ID', required: true },
   ],
+  scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -529,6 +532,7 @@ registerToolDef({
     { name: 'author', type: 'string', description: 'Author name (user or agent)', required: true },
     { name: 'content', type: 'string', description: 'Comment text', required: true },
   ],
+  scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -540,6 +544,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Task ID', required: true },
     { name: 'commentId', type: 'string', description: 'Comment ID to delete', required: true },
   ],
+  scope: 'tasks:write',
 });
 
 export default router;

--- a/packages/control/src/routes/template-sync.ts
+++ b/packages/control/src/routes/template-sync.ts
@@ -23,6 +23,7 @@ registerToolDef({
   parameters: [
     { name: 'name', type: 'string', description: 'Agent name to sync', required: true },
   ],
+    scope: 'templates:write',
 });
 
 const PLUGINS_PATH = '/data/.openclaw/extensions';

--- a/packages/control/src/routes/templates.ts
+++ b/packages/control/src/routes/templates.ts
@@ -19,6 +19,7 @@ registerToolDef({
   description: 'List all armada templates. Shows template ID, name, role, and model.',
   method: 'GET', path: '/api/templates',
   parameters: [],
+    scope: 'templates:read',
 });
 
 registerToolDef({
@@ -28,6 +29,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Template ID', required: true },
   ],
+    scope: 'templates:read',
 });
 
 registerToolDef({
@@ -43,6 +45,7 @@ registerToolDef({
     { name: 'soul', type: 'string', description: 'SOUL.md content — the agent personality' },
     { name: 'agents', type: 'string', description: 'AGENTS.md content — agent instructions' },
   ],
+    scope: 'templates:write',
 });
 
 registerToolDef({
@@ -59,6 +62,7 @@ registerToolDef({
     { name: 'soul', type: 'string', description: 'SOUL.md content' },
     { name: 'agents', type: 'string', description: 'AGENTS.md content' },
   ],
+    scope: 'templates:write',
 });
 
 registerToolDef({
@@ -68,6 +72,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Template ID to delete', required: true },
   ],
+    scope: 'templates:write',
 });
 
 // GET /api/templates
@@ -265,6 +270,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Template ID', required: true },
   ],
+    scope: 'templates:read',
 });
 
 registerToolDef({
@@ -274,6 +280,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Template ID', required: true },
   ],
+    scope: 'templates:write',
 });
 
 export default router;

--- a/packages/control/src/routes/tools.ts
+++ b/packages/control/src/routes/tools.ts
@@ -11,6 +11,7 @@ registerToolDef({
   parameters: [
     { name: 'tools', type: 'string', description: 'GitHub repo slugs (e.g. cli/cli, jqlang/jq) — pass as JSON array', required: true },
   ],
+    scope: 'system:write',
 });
 
 registerToolDef({
@@ -29,6 +30,7 @@ registerToolDef({
   parameters: [
     { name: 'tool', type: 'string', description: 'GitHub repo slug (e.g. cli/cli)', required: true },
   ],
+    scope: 'system:write',
 });
 
 export function createToolRoutes(nodeManager: NodeManager): Router {

--- a/packages/control/src/routes/triage.ts
+++ b/packages/control/src/routes/triage.ts
@@ -7,6 +7,7 @@ registerToolDef({
   description: 'Scan all projects for untriaged GitHub issues and dispatch triage to PM agents.',
   method: 'POST', path: '/api/triage/scan',
   parameters: [],
+    scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -17,6 +18,7 @@ registerToolDef({
     { name: 'projectId', type: 'string', description: 'Project ID', required: true },
     { name: 'issueNumber', type: 'number', description: 'GitHub issue number', required: true },
   ],
+    scope: 'tasks:write',
 });
 
 registerToolDef({
@@ -27,6 +29,7 @@ registerToolDef({
     { name: 'projectId', type: 'string', description: 'Project ID', required: true },
     { name: 'issueNumber', type: 'number', description: 'GitHub issue number', required: true },
   ],
+    scope: 'tasks:write',
 });
 import { triageIssue, handleTriageResult, triageNewIssues, markIssueTriaged } from '../services/triage.js';
 import { getCachedIssues } from '../services/github-sync.js';

--- a/packages/control/src/routes/users.ts
+++ b/packages/control/src/routes/users.ts
@@ -18,6 +18,7 @@ registerToolDef({
   method: 'GET',
   path: '/api/users',
   parameters: [],
+    scope: 'users:read',
 });
 
 registerToolDef({
@@ -28,6 +29,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'User ID or name', required: true },
   ],
+    scope: 'users:read',
 });
 
 registerToolDef({
@@ -43,6 +45,7 @@ registerToolDef({
     { name: 'linkedAccounts', type: 'string', description: 'Linked accounts JSON (telegram, github, email)', required: false },
     { name: 'notifications', type: 'string', description: 'Notification settings JSON', required: false },
   ],
+    scope: 'users:write',
 });
 
 registerToolDef({
@@ -59,6 +62,7 @@ registerToolDef({
     { name: 'linkedAccounts', type: 'string', description: 'Linked accounts JSON', required: false },
     { name: 'notifications', type: 'string', description: 'Notification settings JSON', required: false },
   ],
+    scope: 'users:write',
 });
 
 registerToolDef({
@@ -69,6 +73,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'User ID', required: true },
   ],
+    scope: 'users:write',
 });
 
 // ── Routes ───────────────────────────────────────────────────────────
@@ -194,6 +199,7 @@ registerToolDef({
   description: 'Generate an AI avatar for a armada user.',
   method: 'POST', path: '/api/users/:id/avatar/generate',
   parameters: [{ name: 'id', type: 'string', description: 'User ID', required: true }],
+    scope: 'users:write',
 });
 
 registerToolDef({
@@ -201,6 +207,7 @@ registerToolDef({
   description: 'Delete the avatar for a armada user.',
   method: 'DELETE', path: '/api/users/:id/avatar',
   parameters: [{ name: 'id', type: 'string', description: 'User ID', required: true }],
+    scope: 'users:write',
 });
 
 // GET /api/users/:id/avatar/status — persisted generating flag

--- a/packages/control/src/routes/webhooks-inbound.ts
+++ b/packages/control/src/routes/webhooks-inbound.ts
@@ -37,6 +37,7 @@ registerToolDef({
     { name: 'actionConfig', type: 'string', description: 'Action configuration JSON string (workflowId, projectId, etc.)', required: false },
     { name: 'secret', type: 'string', description: 'Optional HMAC-SHA256 secret for request verification', required: false },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -52,6 +53,7 @@ registerToolDef({
     { name: 'secret', type: 'string', description: 'HMAC secret', required: false },
     { name: 'enabled', type: 'boolean', description: 'Whether the webhook is enabled', required: false },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -62,6 +64,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Webhook ID', required: true },
   ],
+    scope: 'webhooks:write',
 });
 
 // GET /api/webhooks/inbound

--- a/packages/control/src/routes/webhooks.ts
+++ b/packages/control/src/routes/webhooks.ts
@@ -19,6 +19,7 @@ registerToolDef({
   method: 'GET',
   path: '/api/webhooks',
   parameters: [],
+    scope: 'webhooks:read',
 });
 
 registerToolDef({
@@ -31,6 +32,7 @@ registerToolDef({
     { name: 'events', type: 'string', description: 'Comma-separated event types to subscribe to, or * for all', required: false },
     { name: 'secret', type: 'string', description: 'Optional shared secret for HMAC-SHA256 signature verification', required: false },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -45,6 +47,7 @@ registerToolDef({
     { name: 'secret', type: 'string', description: 'Shared secret for HMAC-SHA256 signatures', required: false },
     { name: 'enabled', type: 'boolean', description: 'Whether the webhook is enabled', required: false },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -55,6 +58,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Webhook ID', required: true },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -65,6 +69,7 @@ registerToolDef({
   parameters: [
     { name: 'id', type: 'string', description: 'Webhook ID', required: true },
   ],
+    scope: 'webhooks:write',
 });
 
 registerToolDef({
@@ -73,6 +78,7 @@ registerToolDef({
   method: 'GET',
   path: '/api/webhooks/events',
   parameters: [],
+    scope: 'webhooks:read',
 });
 
 // ── Routes ───────────────────────────────────────────────────────────

--- a/packages/control/src/routes/workflows.ts
+++ b/packages/control/src/routes/workflows.ts
@@ -19,6 +19,7 @@ registerToolDef({
   description: 'List all workflows. Optional projectId filter.',
   method: 'GET', path: '/api/workflows',
   parameters: [{ name: 'projectId', type: 'string', description: 'Filter by project ID' }],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -26,6 +27,7 @@ registerToolDef({
   description: 'Get a workflow by ID. Returns steps, projectIds, enabled status.',
   method: 'GET', path: '/api/workflows/:id',
   parameters: [{ name: 'id', type: 'string', description: 'Workflow ID', required: true }],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -38,6 +40,7 @@ registerToolDef({
     { name: 'projectIds', type: 'string', description: 'JSON array of project IDs to assign' },
     { name: 'steps', type: 'string', description: 'JSON array of workflow steps', required: true },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -52,6 +55,7 @@ registerToolDef({
     { name: 'projectIds', type: 'string', description: 'JSON array of project IDs' },
     { name: 'enabled', type: 'boolean', description: 'Enable/disable workflow' },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -59,6 +63,7 @@ registerToolDef({
   description: 'Delete a workflow.',
   method: 'DELETE', path: '/api/workflows/:id',
   parameters: [{ name: 'id', type: 'string', description: 'Workflow ID', required: true }],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -71,6 +76,7 @@ registerToolDef({
     { name: 'triggerRef', type: 'string', description: 'Trigger reference (e.g. issue URL)' },
     { name: 'vars', type: 'string', description: 'JSON object of template variables' },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -81,6 +87,7 @@ registerToolDef({
     { name: 'id', type: 'string', description: 'Workflow ID', required: true },
     { name: 'limit', type: 'number', description: 'Max runs to return (default 20)' },
   ],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -88,6 +95,7 @@ registerToolDef({
   description: 'Get details of a workflow run including step outputs and context.',
   method: 'GET', path: '/api/workflows/runs/:runId',
   parameters: [{ name: 'runId', type: 'string', description: 'Run ID', required: true }],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -95,6 +103,7 @@ registerToolDef({
   description: 'Get step runs for a workflow run.',
   method: 'GET', path: '/api/workflows/runs/:runId/steps',
   parameters: [{ name: 'runId', type: 'string', description: 'Run ID', required: true }],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -105,6 +114,7 @@ registerToolDef({
     { name: 'runId', type: 'string', description: 'Run ID', required: true },
     { name: 'stepId', type: 'string', description: 'Step ID to approve', required: true },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -116,6 +126,7 @@ registerToolDef({
     { name: 'stepId', type: 'string', description: 'Step ID to reject', required: true },
     { name: 'reason', type: 'string', description: 'Rejection reason' },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -127,6 +138,7 @@ registerToolDef({
     { name: 'stepId', type: 'string', description: 'Step ID to retry', required: true },
     { name: 'feedback', type: 'string', description: 'Feedback for the retry (what was wrong)' },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -134,6 +146,7 @@ registerToolDef({
   description: 'Cancel a workflow run.',
   method: 'POST', path: '/api/workflows/runs/:runId/cancel',
   parameters: [{ name: 'runId', type: 'string', description: 'Run ID', required: true }],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -141,6 +154,7 @@ registerToolDef({
   description: 'Get the full workflow context for a run — all steps, their outputs, agents, and rework history. Agents use this to inspect the workflow state.',
   method: 'GET', path: '/api/workflow-runs/:runId/context',
   parameters: [{ name: 'runId', type: 'string', description: 'Run ID', required: true }],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -153,6 +167,7 @@ registerToolDef({
     { name: 'targetStepId', type: 'string', description: 'Step ID to rework (must be completed)', required: true },
     { name: 'feedback', type: 'string', description: 'Feedback explaining what needs to change', required: true },
   ],
+    scope: 'workflows:write',
 });
 
 registerToolDef({
@@ -160,6 +175,7 @@ registerToolDef({
   description: 'Get all active (running/paused) workflow runs with step data.',
   method: 'GET', path: '/api/workflows/runs/active',
   parameters: [],
+    scope: 'workflows:read',
 });
 
 registerToolDef({
@@ -167,6 +183,7 @@ registerToolDef({
   description: 'Get completed/failed/cancelled workflow runs from the last 24 hours.',
   method: 'GET', path: '/api/workflows/runs/recent',
   parameters: [],
+    scope: 'workflows:read',
 });
 import {
   getWorkflowsForProject,

--- a/packages/control/src/utils/tool-registry.ts
+++ b/packages/control/src/utils/tool-registry.ts
@@ -28,6 +28,8 @@ export interface ToolDefinition {
   responseFormat?: 'json' | 'text';
   /** If true, the tool supports "all" as a target to operate on every agent */
   supportsAll?: boolean;
+  /** Required scope to access this tool. Used for filtering in /api/meta/tools */
+  scope?: string;
 }
 
 const _tools: ToolDefinition[] = [];


### PR DESCRIPTION
Part 1 of #31. Adds scope field to ToolDefinition, populates it from route requireScope() calls, and filters /api/meta/tools by the requester's token scopes. Instance agents now only see tools they have access to.