### PR TITLE
feat: notification linking foundation — channels field, linking service, API endpoints (#63)

### DIFF
--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -323,6 +323,7 @@ export const users = sqliteTable('users', {
   passwordHash: text('password_hash'),
   linkedAccountsJson: text('linked_accounts_json').notNull().default('{}'),
   notificationsJson: text('notifications_json').notNull().default('{}'),
+  channelsJson: text('channels_json').notNull().default('{}'),
   createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   avatarGenerating: integer('avatar_generating').notNull().default(0),
   avatarVersion: integer('avatar_version').notNull().default(0),

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -390,6 +390,22 @@ const migrations: Migration[] = [
       )`,
     ],
   },
+
+  // ── notification channel linking (#63) ────────────────────────────
+  {
+    version: 32,
+    description: 'Add unique constraint on notification_channels.type (#63)',
+    sql: [
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_channels_type ON notification_channels(type)',
+    ],
+  },
+  {
+    version: 33,
+    description: 'Add channels_json column to users table (#63)',
+    sql: [
+      "ALTER TABLE users ADD COLUMN channels_json TEXT NOT NULL DEFAULT '{}'",
+    ],
+  },
 ];
 
 /**

--- a/packages/control/src/db/tables.ts
+++ b/packages/control/src/db/tables.ts
@@ -314,6 +314,7 @@ export function createTables(db: Database.Database): void {
       password_hash        TEXT DEFAULT NULL,
       linked_accounts_json TEXT NOT NULL DEFAULT '{}',
       notifications_json   TEXT NOT NULL DEFAULT '{}',
+      channels_json        TEXT NOT NULL DEFAULT '{}',
       created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
@@ -594,6 +595,7 @@ export function createTables(db: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
       updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_channels_type ON notification_channels(type);
 
     -- ── Schema version tracking ───────────────────────────────────────────
 

--- a/packages/control/src/repositories/user-repo.ts
+++ b/packages/control/src/repositories/user-repo.ts
@@ -2,11 +2,12 @@ import { eq } from 'drizzle-orm';
 import { getDrizzle } from '../db/drizzle.js';
 import { users } from '../db/drizzle-schema.js';
 import type { ArmadaUser } from '@coderage-labs/armada-shared';
-import { parseJsonWithSchema, linkedAccountsSchema, notificationsSchema, defaultNotifications } from '../utils/json-schemas.js';
+import { parseJsonWithSchema, linkedAccountsSchema, notificationsSchema, userChannelsSchema, defaultNotifications } from '../utils/json-schemas.js';
 
 function rowToUser(r: typeof users.$inferSelect): ArmadaUser {
   const linkedAccounts = parseJsonWithSchema('[user-repo] linkedAccounts', r.linkedAccountsJson, linkedAccountsSchema, {}) as ArmadaUser['linkedAccounts'];
   const notifications = parseJsonWithSchema('[user-repo] notifications', r.notificationsJson, notificationsSchema, defaultNotifications()) as ArmadaUser['notifications'];
+  const channels = parseJsonWithSchema('[user-repo] channels', (r as any).channelsJson ?? '{}', userChannelsSchema, {}) as ArmadaUser['channels'];
   return {
     id: r.id,
     name: r.name,
@@ -17,6 +18,7 @@ function rowToUser(r: typeof users.$inferSelect): ArmadaUser {
     avatarGenerating: !!r.avatarGenerating,
     avatarVersion: r.avatarVersion ?? 0,
     linkedAccounts,
+    channels,
     notifications,
     createdAt: r.createdAt,
   };
@@ -37,7 +39,7 @@ export const usersRepo = {
     return row ? rowToUser(row) : null;
   },
 
-  create(data: { name: string; displayName: string; type?: string; role?: string; avatarUrl?: string | null; linkedAccounts?: Record<string, any>; notifications?: Record<string, any> }): ArmadaUser {
+  create(data: { name: string; displayName: string; type?: string; role?: string; avatarUrl?: string | null; linkedAccounts?: Record<string, any>; notifications?: Record<string, any>; channels?: Record<string, any> }): ArmadaUser {
     const id = crypto.randomUUID();
     getDrizzle().insert(users).values({
       id,
@@ -48,15 +50,16 @@ export const usersRepo = {
       avatarUrl: data.avatarUrl ?? null,
       linkedAccountsJson: JSON.stringify(data.linkedAccounts ?? {}),
       notificationsJson: JSON.stringify(data.notifications ?? { channels: [], preferences: { gates: false, completions: false, failures: false } }),
-    }).run();
+      channelsJson: JSON.stringify(data.channels ?? {}),
+    } as any).run();
     return usersRepo.getById(id)!;
   },
 
-  update(id: string, data: Partial<{ name: string; displayName: string; type: string; role: string; avatarUrl: string | null; avatarGenerating: number; avatarVersion: number; linkedAccounts: Record<string, any>; notifications: Record<string, any> }>): ArmadaUser {
+  update(id: string, data: Partial<{ name: string; displayName: string; type: string; role: string; avatarUrl: string | null; avatarGenerating: number; avatarVersion: number; linkedAccounts: Record<string, any>; notifications: Record<string, any>; channels: Record<string, any> }>): ArmadaUser {
     const existing = usersRepo.getById(id);
     if (!existing) throw new Error(`User not found: ${id}`);
 
-    const updates: Partial<typeof users.$inferInsert> = {};
+    const updates: Partial<typeof users.$inferInsert> & { channelsJson?: string } = {};
     if (data.name !== undefined) updates.name = data.name;
     if (data.displayName !== undefined) updates.displayName = data.displayName;
     if (data.type !== undefined) updates.type = data.type;
@@ -66,6 +69,7 @@ export const usersRepo = {
     if (data.avatarVersion !== undefined) updates.avatarVersion = data.avatarVersion;
     if (data.linkedAccounts !== undefined) updates.linkedAccountsJson = JSON.stringify(data.linkedAccounts);
     if (data.notifications !== undefined) updates.notificationsJson = JSON.stringify(data.notifications);
+    if (data.channels !== undefined) updates.channelsJson = JSON.stringify(data.channels);
 
     if (Object.keys(updates).length > 0) {
       getDrizzle().update(users).set(updates).where(eq(users.id, id)).run();

--- a/packages/control/src/routes/auth.ts
+++ b/packages/control/src/routes/auth.ts
@@ -28,6 +28,7 @@ import {
   validateInviteToken,
   acceptInvite,
 } from '../services/auth-service.js';
+import { verifyLinkingCode } from '../services/linking-service.js';
 import { inviteRepo } from '../repositories/invite-repo.js';
 
 const router = Router();
@@ -110,6 +111,55 @@ router.put('/me', (req, res) => {
   } catch (err: any) {
     res.status(500).json({ error: err.message ?? 'Failed to update profile' });
   }
+});
+
+// ── Channel Linking ───────────────────────────────────────────────────
+
+// POST /api/auth/me/link — link a channel identity via verification code
+router.post('/me/link', (req, res) => {
+  if (!req.caller) { res.status(401).json({ error: 'Auth required' }); return; }
+  const { code } = req.body;
+  if (!code) { res.status(400).json({ error: 'code is required' }); return; }
+
+  const result = verifyLinkingCode(code);
+  if (!result) { res.status(400).json({ error: 'Invalid or expired linking code' }); return; }
+
+  const user = usersRepo.getById(req.caller.id);
+  if (!user) { res.status(404).json({ error: 'User not found' }); return; }
+
+  const channels = { ...(user.channels || {}) };
+  channels[result.channelType] = {
+    platformId: result.platformId,
+    verified: true,
+    linkedAt: new Date().toISOString(),
+  };
+
+  usersRepo.update(req.caller.id, { channels });
+  res.json({ ok: true, channel: result.channelType, platformId: result.platformId });
+});
+
+// POST /api/auth/me/unlink — unlink a channel
+router.post('/me/unlink', (req, res) => {
+  if (!req.caller) { res.status(401).json({ error: 'Auth required' }); return; }
+  const { channel } = req.body;
+  if (!channel) { res.status(400).json({ error: 'channel is required' }); return; }
+
+  const user = usersRepo.getById(req.caller.id);
+  if (!user) { res.status(404).json({ error: 'User not found' }); return; }
+
+  const channels = { ...(user.channels || {}) };
+  delete channels[channel];
+
+  usersRepo.update(req.caller.id, { channels });
+  res.json({ ok: true });
+});
+
+// GET /api/auth/me/channels — list linked channels
+router.get('/me/channels', (req, res) => {
+  if (!req.caller) { res.status(401).json({ error: 'Auth required' }); return; }
+  const user = usersRepo.getById(req.caller.id);
+  if (!user) { res.status(404).json({ error: 'User not found' }); return; }
+  res.json(user.channels || {});
 });
 
 // ── Password Authentication ───────────────────────────────────────────

--- a/packages/control/src/services/__tests__/linking-service.test.ts
+++ b/packages/control/src/services/__tests__/linking-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createLinkingCode, verifyLinkingCode, getPendingCode } from '../linking-service.js';
+
+describe('linking-service', () => {
+  // Reset module state between tests by re-importing is not straightforward
+  // with ES modules; instead we rely on the codes being consumed or expired.
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('createLinkingCode returns a 6-digit string', () => {
+    const code = createLinkingCode('telegram', '5059211930');
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  it('verifyLinkingCode returns channel info for a valid code', () => {
+    const code = createLinkingCode('telegram', '5059211930');
+    const result = verifyLinkingCode(code);
+    expect(result).not.toBeNull();
+    expect(result!.channelType).toBe('telegram');
+    expect(result!.platformId).toBe('5059211930');
+  });
+
+  it('verifyLinkingCode returns null for an invalid/unknown code', () => {
+    const result = verifyLinkingCode('000000');
+    expect(result).toBeNull();
+  });
+
+  it('verifyLinkingCode returns null for an expired code', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(now)               // cleanupExpired() inside createLinkingCode
+      .mockReturnValueOnce(now)               // createdAt = now
+      .mockReturnValue(now + 11 * 60 * 1000); // verifyLinkingCode TTL check (>10min)
+
+    const code = createLinkingCode('telegram', '9999999999');
+    const result = verifyLinkingCode(code);
+    expect(result).toBeNull();
+  });
+
+  it('codes are one-time use — second verify returns null', () => {
+    const code = createLinkingCode('slack', 'U12345');
+    const first = verifyLinkingCode(code);
+    expect(first).not.toBeNull();
+    const second = verifyLinkingCode(code);
+    expect(second).toBeNull();
+  });
+
+  it('getPendingCode finds an existing non-expired code', () => {
+    const code = createLinkingCode('telegram', '1234567890');
+    const found = getPendingCode('telegram', '1234567890');
+    expect(found).toBe(code);
+  });
+
+  it('getPendingCode returns null when no code exists for that platform', () => {
+    const found = getPendingCode('telegram', 'nonexistent-id');
+    expect(found).toBeNull();
+  });
+
+  it('getPendingCode returns null for expired code', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(now)               // cleanupExpired() inside createLinkingCode
+      .mockReturnValueOnce(now)               // createdAt = now
+      .mockReturnValue(now + 11 * 60 * 1000); // getPendingCode TTL check (>10min)
+
+    const _code = createLinkingCode('telegram', '8888888888');
+    const found = getPendingCode('telegram', '8888888888');
+    expect(found).toBeNull();
+  });
+});

--- a/packages/control/src/services/linking-service.ts
+++ b/packages/control/src/services/linking-service.ts
@@ -1,0 +1,65 @@
+/**
+ * linking-service.ts
+ *
+ * In-memory store for channel linking codes. Generates 6-digit one-time codes
+ * with a 10-minute TTL that allow users to link their platform identities
+ * (e.g. Telegram user ID) to their Armada account.
+ */
+
+interface LinkingCode {
+  code: string;
+  channelType: string;
+  platformId: string;
+  createdAt: number;
+}
+
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+const pendingCodes = new Map<string, LinkingCode>();
+
+/** Remove expired codes from the store. */
+function cleanupExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of pendingCodes) {
+    if (now - entry.createdAt > TTL_MS) pendingCodes.delete(key);
+  }
+}
+
+/**
+ * Generate a 6-digit linking code for a channel identity.
+ * Cleans up expired codes before generating a new one.
+ */
+export function createLinkingCode(channelType: string, platformId: string): string {
+  cleanupExpired();
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  pendingCodes.set(code, { code, channelType, platformId, createdAt: Date.now() });
+  return code;
+}
+
+/**
+ * Verify a linking code.
+ * Returns { channelType, platformId } on success, or null if invalid/expired.
+ * Codes are one-time use — deleted on successful verification.
+ */
+export function verifyLinkingCode(code: string): { channelType: string; platformId: string } | null {
+  const entry = pendingCodes.get(code);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    pendingCodes.delete(code);
+    return null;
+  }
+  pendingCodes.delete(code); // One-time use
+  return { channelType: entry.channelType, platformId: entry.platformId };
+}
+
+/**
+ * Find a pending (non-expired) code for a given platform identity.
+ * Used by bots to resend the code if the user asks again.
+ */
+export function getPendingCode(channelType: string, platformId: string): string | null {
+  for (const [, entry] of pendingCodes) {
+    if (entry.channelType === channelType && entry.platformId === platformId) {
+      if (Date.now() - entry.createdAt <= TTL_MS) return entry.code;
+    }
+  }
+  return null;
+}

--- a/packages/control/src/utils/json-schemas.ts
+++ b/packages/control/src/utils/json-schemas.ts
@@ -65,6 +65,16 @@ export const templateModelSchema = z.object({
 
 export const stringArraySchema = z.array(z.string());
 
+// ── Channel identity (linking) ─────────────────────────────────────
+
+export const channelIdentitySchema = z.object({
+  platformId: z.string(),
+  verified: z.boolean(),
+  linkedAt: z.string(),
+});
+
+export const userChannelsSchema = z.record(z.string(), channelIdentitySchema);
+
 // ── User JSON fields ───────────────────────────────────────────────
 
 export const linkedAccountsSchema = z.object({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -517,6 +517,13 @@ export interface ArmadaUser {
   avatarGenerating?: boolean;
   avatarVersion?: number;
   linkedAccounts: { telegram?: string; github?: string; email?: string; callbackUrl?: string; hooksToken?: string };
+  channels?: {
+    [type: string]: {
+      platformId: string;
+      verified: boolean;
+      linkedAt: string;
+    };
+  };
   notifications: {
     channels: string[];
     telegram?: { chatId: string };


### PR DESCRIPTION
Part 1 of #63. Adds:\n- Unique constraint on notification_channels.type\n- channels_json column on users table\n- ArmadaUser.channels field in shared types\n- In-memory linking code service (6-digit codes, 10min TTL)\n- API: POST /me/link, POST /me/unlink, GET /me/channels\n- Tests for linking service