### PR TITLE
feat: harden notification delivery — system channel checks, quiet hours (#63)

### DIFF
--- a/packages/control/src/repositories/index.ts
+++ b/packages/control/src/repositories/index.ts
@@ -31,3 +31,5 @@ export { pendingMutationRepo } from './pending-mutation-repo.js';
 export type { PendingMutation } from './pending-mutation-repo.js';
 export { usageRepo } from './usage-repo.js';
 export type { UsageEntry, UsageTotals, UsageByDimension, UsagePeriod } from './usage-repo.js';
+export { notificationChannelRepo } from './notification-channel-repo.js';
+export type { NotificationChannel, NotificationChannelType } from './notification-channel-repo.js';

--- a/packages/control/src/services/__tests__/user-notifier.test.ts
+++ b/packages/control/src/services/__tests__/user-notifier.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for user-notifier delivery hardening (#63)
+ *
+ * Covers:
+ * - System channel checks: delivery skipped when channel not enabled
+ * - User identity checks: delivery skipped when user has no linked identity
+ * - Quiet hours: completion/failure skipped during quiet hours
+ * - Quiet hours: gate always delivered (requires action)
+ * - Overnight quiet hours range (23:00-08:00)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ArmadaUser } from '@coderage-labs/armada-shared';
+
+// ── Module mocking ───────────────────────────────────────────────────
+// NOTE: vi.mock factories are hoisted — do NOT reference outer variables inside them.
+// Use vi.fn() directly; retrieve references via the mocked module after import.
+
+vi.mock('../../repositories/index.js', () => ({
+  notificationChannelRepo: { getEnabled: vi.fn() },
+  usersRepo: { getAll: vi.fn() },
+  userProjectsRepo: { getUsersForProject: vi.fn() },
+}));
+
+vi.mock('../telegram-bot.js', () => ({
+  sendGateNotification: vi.fn(),
+  sendPlainNotification: vi.fn(),
+}));
+
+vi.mock('../../db/drizzle.js', () => ({
+  getDrizzle: () => ({
+    update: () => ({
+      set: () => ({ where: () => ({ run: vi.fn() }) }),
+    }),
+  }),
+}));
+
+vi.mock('../../db/drizzle-schema.js', () => ({
+  workflowStepRuns: {},
+}));
+
+// ── Import after mocks ───────────────────────────────────────────────
+
+import { notifyGate, notifyCompletion, isInQuietHours } from '../user-notifier.js';
+import { notificationChannelRepo, usersRepo, userProjectsRepo } from '../../repositories/index.js';
+import { sendGateNotification, sendPlainNotification } from '../telegram-bot.js';
+
+// Typed mock helpers
+const mockGetEnabled = vi.mocked(notificationChannelRepo.getEnabled);
+const mockGetAll = vi.mocked(usersRepo.getAll);
+const mockGetUsersForProject = vi.mocked(userProjectsRepo.getUsersForProject);
+const mockSendGateNotification = vi.mocked(sendGateNotification);
+const mockSendPlainNotification = vi.mocked(sendPlainNotification);
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<ArmadaUser> = {}): ArmadaUser {
+  return {
+    id: 'user-1',
+    name: 'testuser',
+    displayName: 'Test User',
+    type: 'human',
+    role: 'owner',
+    avatarUrl: null,
+    linkedAccounts: {},
+    channels: {},
+    notifications: {
+      channels: [],
+      preferences: { gates: true, completions: true, failures: true },
+    },
+    createdAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeTelegramChannel() {
+  return {
+    id: 'ch-1',
+    type: 'telegram' as const,
+    name: 'Telegram',
+    enabled: true,
+    config: {},
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+// ── isInQuietHours unit tests ────────────────────────────────────────
+
+describe('isInQuietHours', () => {
+  it('returns false when no quiet hours configured', () => {
+    const user = makeUser();
+    expect(isInQuietHours(user)).toBe(false);
+  });
+
+  it('returns false when quiet hours start/end are empty strings', () => {
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '', end: '' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(false);
+  });
+
+  it('returns true during daytime quiet hours (within range)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T14:30:00Z')); // 14:30 UTC
+
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '13:00', end: '17:00' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('returns false outside daytime quiet hours', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T10:00:00Z')); // 10:00 UTC
+
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '13:00', end: '17:00' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('returns true during overnight quiet hours (23:00-08:00) — past midnight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T02:00:00Z')); // 02:00 UTC
+
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('returns true during overnight quiet hours (23:00-08:00) — before midnight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T23:30:00Z')); // 23:30 UTC
+
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('returns false outside overnight quiet hours', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z')); // 12:00 UTC
+
+    const user = makeUser({
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    expect(isInQuietHours(user)).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
+// ── Delivery: system channel checks ─────────────────────────────────
+
+describe('deliverToUser — system channel checks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUsersForProject.mockReturnValue([]);
+  });
+
+  it('skips Telegram delivery when system channel is not enabled', async () => {
+    mockGetEnabled.mockReturnValue([]); // No enabled system channels
+
+    const user = makeUser({
+      channels: { telegram: { platformId: '12345', verified: true, linkedAt: '' } },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).not.toHaveBeenCalled();
+  });
+
+  it('delivers Telegram when system channel is enabled and user is linked', async () => {
+    mockGetEnabled.mockReturnValue([makeTelegramChannel()]);
+    mockSendPlainNotification.mockResolvedValue(undefined);
+
+    const user = makeUser({
+      channels: { telegram: { platformId: '12345', verified: true, linkedAt: '' } },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).toHaveBeenCalledWith('12345', expect.any(String));
+  });
+
+  it('skips Telegram delivery when user has no linked identity', async () => {
+    mockGetEnabled.mockReturnValue([makeTelegramChannel()]); // System channel enabled...
+
+    const user = makeUser({
+      channels: {}, // ...but user has no linked telegram
+      notifications: {
+        channels: [],
+        preferences: { gates: true, completions: true, failures: true },
+        // No legacy telegram.chatId either
+      },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy telegram.chatId when user.channels.telegram is absent', async () => {
+    mockGetEnabled.mockReturnValue([makeTelegramChannel()]);
+    mockSendPlainNotification.mockResolvedValue(undefined);
+
+    const user = makeUser({
+      channels: {},
+      notifications: {
+        channels: [],
+        telegram: { chatId: 'legacy-chat-id' },
+        preferences: { gates: true, completions: true, failures: true },
+      },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).toHaveBeenCalledWith('legacy-chat-id', expect.any(String));
+  });
+});
+
+// ── Quiet hours: notifyCompletion ────────────────────────────────────
+
+describe('notifyCompletion — quiet hours', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUsersForProject.mockReturnValue([]);
+    mockGetEnabled.mockReturnValue([makeTelegramChannel()]);
+    mockSendPlainNotification.mockResolvedValue(undefined);
+  });
+
+  it('skips completion notification during quiet hours', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T02:00:00Z')); // 02:00 UTC — within 23:00-08:00
+
+    const user = makeUser({
+      channels: { telegram: { platformId: '12345', verified: true, linkedAt: '' } },
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('delivers completion notification outside quiet hours', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z')); // 12:00 UTC — outside 23:00-08:00
+
+    const user = makeUser({
+      channels: { telegram: { platformId: '12345', verified: true, linkedAt: '' } },
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(mockSendPlainNotification).toHaveBeenCalledWith('12345', expect.any(String));
+    vi.useRealTimers();
+  });
+});
+
+// ── Quiet hours: notifyGate ──────────────────────────────────────────
+
+describe('notifyGate — quiet hours', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUsersForProject.mockReturnValue([]);
+    mockGetEnabled.mockReturnValue([makeTelegramChannel()]);
+    mockSendGateNotification.mockResolvedValue(42);
+  });
+
+  it('delivers gate notification even during quiet hours (gates require action)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T02:00:00Z')); // 02:00 UTC — within 23:00-08:00
+
+    const user = makeUser({
+      channels: { telegram: { platformId: '12345', verified: true, linkedAt: '' } },
+      notifications: {
+        channels: [],
+        preferences: {
+          gates: true, completions: true, failures: true,
+          quietHours: { start: '23:00', end: '08:00' },
+        },
+      },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyGate({
+      workflowName: 'test-workflow',
+      stepId: 'approval-gate',
+      runId: 'run-1',
+      previousOutput: null,
+      projectId: 'proj-1',
+    });
+
+    // Gate should still be delivered despite quiet hours
+    expect(mockSendGateNotification).toHaveBeenCalledWith(
+      '12345',
+      expect.any(String),
+      'run-1',
+      'approval-gate',
+    );
+    vi.useRealTimers();
+  });
+});
+
+// ── Callback URL delivery ────────────────────────────────────────────
+
+describe('deliverToUser — callback URL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUsersForProject.mockReturnValue([]);
+    mockGetEnabled.mockReturnValue([]); // No system channels
+  });
+
+  it('delivers via callback URL for operator users regardless of system channels', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const user = makeUser({
+      type: 'operator',
+      linkedAccounts: { callbackUrl: 'https://example.com', hooksToken: 'tok-123' },
+    });
+    mockGetAll.mockReturnValue([user]);
+
+    await notifyCompletion({
+      workflowName: 'test-workflow',
+      runId: 'run-1',
+      status: 'completed',
+      projectId: 'proj-1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/armada/notify',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer tok-123' }),
+      }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/control/src/services/user-notifier.ts
+++ b/packages/control/src/services/user-notifier.ts
@@ -2,13 +2,19 @@
  * User Notifier — sends notifications to users based on their preferences.
  *
  * Delivery channels:
- * - Telegram: via grammy bot instance (requires TELEGRAM_BOT_TOKEN env var)
+ * - Telegram: via grammy bot instance (requires system channel to be configured + enabled)
  * - Callback URL: HTTP POST to operator's OpenClaw hooks endpoint (for operator-type users like Robin)
  * - Webhook: HTTP POST to configured webhook URL
+ *
+ * Delivery rules:
+ * 1. System channel must be configured and enabled (notificationChannelRepo.getEnabled())
+ * 2. User must have a linked identity for that channel (user.channels)
+ * 3. User preferences must allow it
+ * 4. Not in quiet hours (for non-critical notifications like completions)
  */
 
 import type { ArmadaUser } from '@coderage-labs/armada-shared';
-import { usersRepo, userProjectsRepo } from '../repositories/index.js';
+import { usersRepo, userProjectsRepo, notificationChannelRepo } from '../repositories/index.js';
 import { sendGateNotification, sendPlainNotification } from './telegram-bot.js';
 import { getDrizzle } from '../db/drizzle.js';
 import { workflowStepRuns } from '../db/drizzle-schema.js';
@@ -41,12 +47,44 @@ export interface NotifyCompletionOptions {
   projectId: string;
 }
 
+// ── Quiet hours ─────────────────────────────────────────────────────
+
+/**
+ * Returns true if the current time falls within the user's configured quiet hours.
+ * Handles overnight ranges (e.g. 23:00 → 08:00).
+ */
+export function isInQuietHours(user: ArmadaUser): boolean {
+  const quiet = user.notifications?.preferences?.quietHours;
+  if (!quiet?.start || !quiet?.end) return false;
+
+  const tz = (quiet as any).tz || 'UTC';
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: tz,
+  });
+  const currentTime = formatter.format(new Date());
+
+  const start = quiet.start; // e.g. "23:00"
+  const end = quiet.end;     // e.g. "08:00"
+
+  // Handle overnight range (23:00 → 08:00)
+  if (start > end) {
+    return currentTime >= start || currentTime < end;
+  }
+  return currentTime >= start && currentTime < end;
+}
+
+// ── Public notification functions ───────────────────────────────────
+
 /**
  * Notify users when a manual gate is reached.
  * - Filtered by project assignment (falls back to all users if no assignments)
  * - Filtered by gatePolicy.notifyOnly if set
  * - operator users: always notified (unless excluded by gatePolicy)
  * - human users: only if notifications.preferences.gates === true
+ * - Gates are always delivered regardless of quiet hours (they require action)
  */
 export async function notifyGate(opts: NotifyGateOptions): Promise<void> {
   const { workflowName, stepId, runId, previousOutput, projectId, gatePolicy } = opts;
@@ -71,6 +109,8 @@ export async function notifyGate(opts: NotifyGateOptions): Promise<void> {
         (user.type === 'human' && user.notifications?.preferences?.gates === true);
 
       if (!shouldNotify) continue;
+
+      // Gates always deliver — they require human action, quiet hours do not apply
 
       const message = formatGateMessage(workflowName, stepId, runId, previousOutput);
       const telegramResult = await deliverToUser(user, message, {
@@ -105,6 +145,7 @@ export async function notifyGate(opts: NotifyGateOptions): Promise<void> {
  * - Filtered by project assignment (falls back to all users if no assignments)
  * - operator users: always notified
  * - human users: only if matching preference (completions/failures) is true
+ * - Completions/failures are skipped during quiet hours
  */
 export async function notifyCompletion(opts: NotifyCompletionOptions): Promise<void> {
   const { workflowName, runId, status, projectId } = opts;
@@ -125,6 +166,12 @@ export async function notifyCompletion(opts: NotifyCompletionOptions): Promise<v
 
       if (!shouldNotify) continue;
 
+      // Skip completions/failures during quiet hours — they are non-critical
+      if (isInQuietHours(user)) {
+        console.log(`[user-notifier] Skipping ${status} notification for ${user.name} — quiet hours`);
+        continue;
+      }
+
       const message = formatCompletionMessage(workflowName, runId, status);
       await deliverToUser(user, message, {
         event: `workflow.${status}`,
@@ -144,32 +191,42 @@ async function deliverToUser(
   message: string,
   payload: Record<string, any>,
 ): Promise<TelegramNotification | null> {
-  const channels = user.notifications?.channels || [];
-  let telegramResult: TelegramNotification | null = null;
+  // Get system-configured channels that are enabled
+  const enabledChannels = notificationChannelRepo.getEnabled();
+  const enabledTypes = new Set(enabledChannels.map(c => c.type));
 
+  const userChannels = user.channels || {};
+
+  let telegramResult: TelegramNotification | null = null;
   const deliveries: Promise<void>[] = [];
 
-  // Telegram delivery — prefer new user.channels field, fall back to legacy notifications.telegram.chatId
-  const telegramId = user.channels?.telegram?.platformId || user.notifications?.telegram?.chatId;
-  if (channels.includes('telegram') && telegramId) {
+  // Telegram — system channel must be enabled + user must have a linked identity
+  // Backwards compat: fall back to legacy notifications.telegram.chatId
+  const telegramId = userChannels.telegram?.platformId || user.notifications?.telegram?.chatId;
+  if (enabledTypes.has('telegram') && telegramId) {
     const isGate = payload.event === 'workflow.gate';
-    const chatId = telegramId;
     deliveries.push(
-      sendTelegram(chatId, message, isGate, payload.runId, payload.stepId).then(msgId => {
-        if (msgId !== null) telegramResult = { chatId, messageId: msgId };
+      sendTelegram(telegramId, message, isGate, payload.runId, payload.stepId).then(msgId => {
+        if (msgId !== null) telegramResult = { chatId: telegramId, messageId: msgId };
       })
     );
   }
 
-  // Callback URL delivery (operator users — always delivers if configured, independent of channels array)
+  // Callback URL — operator users, independent of channel system
+  // This is always attempted if configured (no system channel check)
   if (user.linkedAccounts?.callbackUrl && user.linkedAccounts?.hooksToken) {
     deliveries.push(sendCallback(user.linkedAccounts.callbackUrl, user.linkedAccounts.hooksToken, payload));
   }
 
-  // Webhook delivery
-  if (channels.includes('webhook') && user.notifications?.webhook?.url) {
-    deliveries.push(sendWebhook(user.notifications.webhook.url, undefined, payload));
+  // Webhook — user must have webhook config; independent of channel system
+  const webhookUrl = user.notifications?.webhook?.url;
+  if (webhookUrl) {
+    deliveries.push(sendWebhook(webhookUrl, user.notifications?.webhook?.secret, payload));
   }
+
+  // Future channels — same pattern:
+  // if (enabledTypes.has('slack') && userChannels.slack?.platformId) { ... }
+  // if (enabledTypes.has('email') && userChannels.email?.platformId) { ... }
 
   await Promise.allSettled(deliveries);
   return telegramResult;


### PR DESCRIPTION
Part 3 of #63. Delivery now verifies system channels are configured and enabled before attempting delivery. Adds quiet hours support (completions suppressed, gates always deliver). Cleans up delivery logic with proper channel validation.