### PR TITLE
feat: Discord bot integration with interactive gate notifications (#63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,136 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
@@ -2793,6 +2923,39 @@
         "linux"
       ]
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@simplewebauthn/browser": {
       "version": "11.0.0",
       "license": "MIT",
@@ -3700,6 +3863,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4572,6 +4745,42 @@
       "version": "1.2.2",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.42",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+      "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -5805,6 +6014,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "dev": true,
@@ -6601,6 +6816,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6649,6 +6870,12 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -6679,6 +6906,12 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -8599,6 +8832,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
@@ -8671,6 +8910,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -9648,6 +9896,7 @@
         "better-sqlite3": "^12.6.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
+        "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.1",
         "express": "^4.21.2",
         "grammy": "^1.41.1",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -26,6 +26,7 @@
     "better-sqlite3": "^12.6.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
+    "discord.js": "^14.25.1",
     "drizzle-orm": "^0.45.1",
     "express": "^4.21.2",
     "grammy": "^1.41.1",

--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -10,6 +10,7 @@ import { startWorkspaceRetention, stopWorkspaceRetention } from './services/work
 import { startGithubSyncScheduler, stopGithubSyncScheduler } from './services/github-sync.js';
 import { initTelegramBot, stopTelegramBot } from './services/telegram-bot.js';
 import { initSlackBot } from './services/slack-bot.js';
+import { initDiscordBot } from './services/discord-bot.js';
 import { registerAllProviders } from './services/integrations/index.js';
 import { startVersionChecker, stopVersionChecker } from './services/version-checker.js';
 import { startStuckDetector, stopStuckDetector } from './services/stuck-detector.js';
@@ -140,6 +141,9 @@ async function start() {
 
   // ── Slack bot ───────────────────────────────────────────────────────
   initSlackBot();
+
+  // ── Discord bot ─────────────────────────────────────────────────────
+  initDiscordBot();
 
   // Cleanup on shutdown
   const shutdown = async () => {

--- a/packages/control/src/routes/notification-channels.ts
+++ b/packages/control/src/routes/notification-channels.ts
@@ -24,7 +24,7 @@ registerToolDef({
     { name: 'type', type: 'string', description: 'Channel type: telegram | slack | discord | email', required: true },
     { name: 'name', type: 'string', description: 'Display name for this channel', required: true },
     { name: 'enabled', type: 'boolean', description: 'Whether the channel is enabled', required: false },
-    { name: 'config', type: 'string', description: 'Channel-specific config as JSON. Examples: Telegram: { "token": "...", "chat_id": "..." } (chat_id is fallback only — per-user delivery uses each user\'s own notification preferences). Slack: { "token": "xoxb-...", "signingSecret": "...", "appToken": "xapp-..." } (appToken optional, enables Socket Mode — no public URL needed). Discord/other: { "webhook_url": "..." }', required: true },
+    { name: 'config', type: 'string', description: 'Channel-specific config as JSON. Examples: Telegram: { "token": "...", "chat_id": "..." } (chat_id is fallback only — per-user delivery uses each user\'s own notification preferences). Slack: { "token": "xoxb-...", "signingSecret": "...", "appToken": "xapp-..." } (appToken optional, enables Socket Mode — no public URL needed). Discord: { "token": "Bot token from Discord Developer Portal" }', required: true },
   ],
     scope: 'system:write',
 });

--- a/packages/control/src/services/discord-bot.ts
+++ b/packages/control/src/services/discord-bot.ts
@@ -1,0 +1,194 @@
+/**
+ * discord-bot.ts
+ *
+ * Discord bot integration for Armada notifications.
+ * Handles DM linking flow and gate notifications with interactive buttons.
+ *
+ * Bot commands (DM only):
+ *   !link / !start — generate a linking code
+ *   !status        — check linked account
+ *   !help          — show help message
+ */
+
+import { Client, GatewayIntentBits, ActionRowBuilder, ButtonBuilder, ButtonStyle, Events } from 'discord.js';
+import { createLinkingCode, getPendingCode } from './linking-service.js';
+import { usersRepo } from '../repositories/index.js';
+import { notificationChannelRepo } from '../repositories/index.js';
+
+let client: Client | null = null;
+
+export function initDiscordBot(): void {
+  const channels = notificationChannelRepo.getByType('discord');
+  const channel = channels.find(c => c.enabled);
+  if (!channel) {
+    console.log('[discord-bot] No enabled Discord channel configured, skipping init');
+    return;
+  }
+
+  const { token } = channel.config as { token?: string };
+  if (!token) {
+    console.error('[discord-bot] Discord channel config missing bot token');
+    return;
+  }
+
+  client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.DirectMessages,
+      GatewayIntentBits.MessageContent,
+    ],
+  });
+
+  client.on(Events.MessageCreate, async (message) => {
+    // Only handle DMs, ignore bot messages
+    if (!message.guild && !message.author.bot) {
+      const content = message.content.trim().toLowerCase();
+      const discordUserId = message.author.id;
+
+      if (content === '!link' || content === '!start') {
+        // Check if already linked
+        const users = usersRepo.getAll();
+        const existingUser = users.find(u =>
+          u.channels?.discord?.platformId === discordUserId
+        );
+
+        if (existingUser) {
+          await message.reply(`✅ You're already linked as **${existingUser.displayName}** (${existingUser.name}). You'll receive notifications here.`);
+          return;
+        }
+
+        const existing = getPendingCode('discord', discordUserId);
+        if (existing) {
+          await message.reply(`Your linking code is still active: \`${existing}\`\n\nEnter this on your Armada Account page. Expires in 10 minutes.`);
+          return;
+        }
+
+        const code = createLinkingCode('discord', discordUserId);
+        await message.reply(`👋 Welcome! To link your Discord to Armada, enter this code on your Account page:\n\n\`${code}\`\n\nThis code expires in 10 minutes.`);
+      } else if (content === '!status') {
+        const users = usersRepo.getAll();
+        const user = users.find(u => u.channels?.discord?.platformId === discordUserId);
+        if (user) {
+          await message.reply(`✅ Linked as **${user.displayName}** (${user.name})`);
+        } else {
+          await message.reply('❌ Not linked. Send `!link` to link your Discord account.');
+        }
+      } else if (content === '!help') {
+        await message.reply(
+          '🤖 **Armada Bot**\n\n' +
+          '`!link` — Link your Discord account\n' +
+          '`!status` — Check your linked account\n' +
+          '`!help` — Show this message'
+        );
+      }
+    }
+  });
+
+  // Handle button interactions (gate approve/reject)
+  client.on(Events.InteractionCreate, async (interaction) => {
+    if (!interaction.isButton()) return;
+
+    const discordUserId = interaction.user.id;
+    const users = usersRepo.getAll();
+    const user = users.find(u => u.channels?.discord?.platformId === discordUserId);
+
+    if (!user) {
+      await interaction.reply({ content: '❌ Your Discord account is not linked to Armada. DM me `!link` to set up.', ephemeral: true });
+      return;
+    }
+
+    const [action, runId, stepId] = interaction.customId.split(':');
+
+    if (!runId || !stepId) {
+      await interaction.reply({ content: '❌ Invalid action data.', ephemeral: true });
+      return;
+    }
+
+    try {
+      if (action === 'gate_approve') {
+        const { approveGate } = await import('./workflow-engine.js');
+        approveGate(runId, stepId, user.id);
+        await interaction.update({ content: `✅ Gate **${stepId}** approved by ${user.displayName}`, components: [] });
+      } else if (action === 'gate_reject') {
+        const { rejectGate } = await import('./workflow-engine.js');
+        rejectGate(runId, stepId, 'Rejected via Discord', user.id);
+        await interaction.update({ content: `❌ Gate **${stepId}** rejected by ${user.displayName}`, components: [] });
+      }
+    } catch (err: any) {
+      await interaction.reply({ content: `❌ Failed: ${err.message}`, ephemeral: true });
+    }
+  });
+
+  client.on(Events.ClientReady, () => {
+    console.log(`[discord-bot] Logged in as ${client!.user?.tag}`);
+  });
+
+  client.login(token).catch(err => {
+    console.error(`[discord-bot] Failed to login: ${err.message}`);
+  });
+}
+
+/**
+ * Convert HTML-formatted message (used by Telegram) to Discord markdown.
+ * Discord uses markdown; Telegram uses HTML.
+ */
+export function htmlToDiscordMarkdown(html: string): string {
+  return html
+    .replace(/<b>(.*?)<\/b>/gs, '**$1**')
+    .replace(/<i>(.*?)<\/i>/gs, '*$1*')
+    .replace(/<code>(.*?)<\/code>/gs, '`$1`')
+    .replace(/<pre>(.*?)<\/pre>/gs, '```\n$1\n```')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+/** Send a gate notification with approve/reject buttons via DM */
+export async function sendDiscordGateNotification(
+  userId: string,
+  message: string,
+  runId: string,
+  stepId: string,
+): Promise<void> {
+  if (!client) return;
+
+  try {
+    const user = await client.users.fetch(userId);
+    const dm = await user.createDM();
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`gate_approve:${runId}:${stepId}`)
+        .setLabel('✅ Approve')
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(`gate_reject:${runId}:${stepId}`)
+        .setLabel('❌ Reject')
+        .setStyle(ButtonStyle.Danger),
+    );
+
+    await dm.send({ content: htmlToDiscordMarkdown(message), components: [row] });
+  } catch (err: any) {
+    console.error(`[discord-bot] Failed to send gate notification: ${err.message}`);
+  }
+}
+
+/** Send a plain notification via DM */
+export async function sendDiscordNotification(
+  userId: string,
+  message: string,
+): Promise<void> {
+  if (!client) return;
+
+  try {
+    const user = await client.users.fetch(userId);
+    const dm = await user.createDM();
+    await dm.send(htmlToDiscordMarkdown(message));
+  } catch (err: any) {
+    console.error(`[discord-bot] Failed to send notification: ${err.message}`);
+  }
+}
+
+export function getDiscordClient(): Client | null {
+  return client;
+}

--- a/packages/control/src/services/user-notifier.ts
+++ b/packages/control/src/services/user-notifier.ts
@@ -17,6 +17,7 @@ import type { ArmadaUser } from '@coderage-labs/armada-shared';
 import { usersRepo, userProjectsRepo, notificationChannelRepo } from '../repositories/index.js';
 import { sendGateNotification, sendPlainNotification } from './telegram-bot.js';
 import { sendSlackGateNotification, sendSlackNotification } from './slack-bot.js';
+import { sendDiscordGateNotification, sendDiscordNotification } from './discord-bot.js';
 import { getDrizzle } from '../db/drizzle.js';
 import { workflowStepRuns } from '../db/drizzle-schema.js';
 import { and, eq, sql } from 'drizzle-orm';
@@ -222,6 +223,17 @@ async function deliverToUser(
       deliveries.push(sendSlackGateNotification(slackId, slackMessage, payload.runId, payload.stepId));
     } else {
       deliveries.push(sendSlackNotification(slackId, slackMessage));
+    }
+  }
+
+  // Discord — system channel must be enabled + user must have a linked identity
+  const discordId = userChannels.discord?.platformId;
+  if (enabledTypes.has('discord') && discordId) {
+    const isGate = payload.event === 'workflow.gate';
+    if (isGate && payload.runId && payload.stepId) {
+      deliveries.push(sendDiscordGateNotification(discordId, message, payload.runId, payload.stepId));
+    } else {
+      deliveries.push(sendDiscordNotification(discordId, message));
     }
   }
 


### PR DESCRIPTION
Part of #63. Adds Discord bot via discord.js with:
- DM linking flow (!link, !status, !help commands)
- Gate notifications with approve/reject buttons
- Completion/failure DM notifications
- Bot token read from notification_channels config