### PR TITLE
feat: project responsibility assignments — triager, approver, owner (#77)

### DIFF
--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -20,6 +20,7 @@ import { createSkillRoutes } from './routes/skills.js';
 import taskRoutes from './routes/tasks.js';
 import activityRoutes from './routes/activity.js';
 import projectRoutes from './routes/projects.js';
+import assignmentRoutes from './routes/assignments.js';
 import integrationsRoutes, { projectIntegrationsRouter } from './routes/integrations.js';
 import proxyRoutes from './routes/proxy.js';
 import prProxyRoutes from './routes/proxy-prs.js';
@@ -106,6 +107,7 @@ export function createApp(opts: AppOptions): express.Express {
   app.use('/api/proxy/issues', proxyRoutes);
   app.use('/api/proxy/prs', prProxyRoutes);
   app.use('/api/projects', projectRoutes);
+  app.use('/api/projects/:id/assignments', assignmentRoutes);
   app.use('/api/projects/:id/integrations', projectIntegrationsRouter);
   app.use('/api/webhooks', webhookRoutes);
   app.use('/api/webhooks/inbound', webhooksInboundMgmtRouter);

--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -2,7 +2,7 @@
  * Drizzle ORM schema — mirrors the existing SQLite tables exactly.
  * This is additive only; the existing raw-SQL schema.ts is untouched.
  */
-import { sqliteTable, text, integer, real, primaryKey, unique } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real, primaryKey, unique, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 // ── nodes ────────────────────────────────────────────────────────────
@@ -624,6 +624,19 @@ export const pendingMutations = sqliteTable('pending_mutations', {
   instanceId: text('instance_id'),
   createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
+
+// ── project_assignments (#77) ────────────────────────────────────────
+export const projectAssignments = sqliteTable('project_assignments', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  assignmentType: text('assignment_type').notNull(), // 'triager' | 'approver' | 'owner'
+  assigneeType: text('assignee_type').notNull(),     // 'user' | 'agent' | 'role'
+  assigneeId: text('assignee_id').notNull(),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+}, (table) => [
+  uniqueIndex('project_assignment_unique').on(table.projectId, table.assignmentType),
+]);
 
 // ── notification_channels (#512) ────────────────────────────────────
 export const notificationChannels = sqliteTable('notification_channels', {

--- a/packages/control/src/db/tables.ts
+++ b/packages/control/src/db/tables.ts
@@ -597,6 +597,19 @@ export function createTables(db: Database.Database): void {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_channels_type ON notification_channels(type);
 
+    -- ── project_assignments (#77) ─────────────────────────────────────────
+
+    CREATE TABLE IF NOT EXISTS project_assignments (
+      id               TEXT PRIMARY KEY,
+      project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      assignment_type  TEXT NOT NULL,
+      assignee_type    TEXT NOT NULL,
+      assignee_id      TEXT NOT NULL,
+      created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS project_assignment_unique ON project_assignments(project_id, assignment_type);
+
     -- ── Schema version tracking ───────────────────────────────────────────
 
     CREATE TABLE IF NOT EXISTS schema_version (

--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -4,7 +4,7 @@ import { getDb } from './db/index.js';
 import { NodeManager } from './node-manager.js';
 import { createApp, attachWebSocketUpgrade } from './app.js';
 import { generateInstallScript } from './install-script.js';
-import { nodesRepo, agentsRepo } from './repositories/index.js';
+import { nodesRepo, agentsRepo, migrateOwnerAssignments } from './repositories/index.js';
 import { startHealthMonitor, stopHealthMonitor } from './services/health-monitor.js';
 import { startWorkspaceRetention, stopWorkspaceRetention } from './services/workspace-retention.js';
 import { startGithubSyncScheduler, stopGithubSyncScheduler } from './services/github-sync.js';
@@ -29,6 +29,13 @@ async function start() {
 
   // Seed default plugins
   pluginManager.seed();
+
+  // Migrate legacy owner assignments to project_assignments table (#77)
+  try {
+    migrateOwnerAssignments();
+  } catch (err: any) {
+    console.warn('[startup] Owner assignment migration failed (non-fatal):', err.message);
+  }
 
   // Register integration providers
   console.log('🔌 Registering integration providers…');

--- a/packages/control/src/repositories/assignment-repo.ts
+++ b/packages/control/src/repositories/assignment-repo.ts
@@ -1,0 +1,310 @@
+/**
+ * Assignment Repository — project responsibility assignments (#77)
+ *
+ * Manages the three mutex responsibility roles for a project:
+ *   triager  — routes new issues to the right workflow
+ *   approver — approves PRs / completed tasks
+ *   owner    — project owner / final escalation target
+ *
+ * Each assignment slot can be filled by a 'user', 'agent', or 'role'.
+ * Role-based assignments are resolved dynamically at call time.
+ */
+import { eq, and } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzle } from '../db/drizzle.js';
+import { projectAssignments, agents, users, userProjects, roleMetadata } from '../db/drizzle-schema.js';
+import { sql } from 'drizzle-orm';
+
+export type AssignmentType = 'triager' | 'approver' | 'owner';
+export type AssigneeType = 'user' | 'agent' | 'role';
+
+export interface Assignment {
+  id: string;
+  projectId: string;
+  assignmentType: AssignmentType;
+  assigneeType: AssigneeType;
+  assigneeId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ResolvedAssignee {
+  type: 'user' | 'agent';
+  id: string;
+  name?: string;
+  displayName?: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function rowToAssignment(r: typeof projectAssignments.$inferSelect): Assignment {
+  return {
+    id: r.id,
+    projectId: r.projectId,
+    assignmentType: r.assignmentType as AssignmentType,
+    assigneeType: r.assigneeType as AssigneeType,
+    assigneeId: r.assigneeId,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+function isAgentHealthy(agent: typeof agents.$inferSelect): boolean {
+  return agent.status === 'running' || agent.healthStatus === 'healthy';
+}
+
+// ── Repository ───────────────────────────────────────────────────────
+
+export const assignmentRepo = {
+  /**
+   * Get a single assignment for a project/type combo.
+   */
+  getAssignment(projectId: string, assignmentType: AssignmentType): Assignment | null {
+    const row = getDrizzle()
+      .select()
+      .from(projectAssignments)
+      .where(and(
+        eq(projectAssignments.projectId, projectId),
+        eq(projectAssignments.assignmentType, assignmentType),
+      ))
+      .get();
+    return row ? rowToAssignment(row) : null;
+  },
+
+  /**
+   * Upsert an assignment (mutex via UNIQUE constraint).
+   */
+  setAssignment(
+    projectId: string,
+    assignmentType: AssignmentType,
+    assigneeType: AssigneeType,
+    assigneeId: string,
+  ): Assignment {
+    const db = getDrizzle();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    db.insert(projectAssignments).values({
+      id,
+      projectId,
+      assignmentType,
+      assigneeType,
+      assigneeId,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [projectAssignments.projectId, projectAssignments.assignmentType],
+      set: {
+        assigneeType,
+        assigneeId,
+        updatedAt: now,
+      },
+    }).run();
+
+    return assignmentRepo.getAssignment(projectId, assignmentType)!;
+  },
+
+  /**
+   * Remove a specific assignment.
+   */
+  removeAssignment(projectId: string, assignmentType: AssignmentType): void {
+    getDrizzle()
+      .delete(projectAssignments)
+      .where(and(
+        eq(projectAssignments.projectId, projectId),
+        eq(projectAssignments.assignmentType, assignmentType),
+      ))
+      .run();
+  },
+
+  /**
+   * Get all assignments for a project.
+   */
+  getAssignmentsForProject(projectId: string): Assignment[] {
+    return getDrizzle()
+      .select()
+      .from(projectAssignments)
+      .where(eq(projectAssignments.projectId, projectId))
+      .all()
+      .map(rowToAssignment);
+  },
+
+  /**
+   * Remove all assignments for a given assignee (for cleanup on delete).
+   */
+  removeAssignmentsForAssignee(assigneeType: AssigneeType, assigneeId: string): number {
+    const result = getDrizzle()
+      .delete(projectAssignments)
+      .where(and(
+        eq(projectAssignments.assigneeType, assigneeType),
+        eq(projectAssignments.assigneeId, assigneeId),
+      ))
+      .run();
+    return result.changes;
+  },
+
+  /**
+   * Resolve the triager for a project.
+   * Priority chain:
+   *   1. Explicit assignment → validate exists & healthy
+   *   2. Role-based → find healthy agent with that role in the project
+   *   3. Owner assignment (fall back to owner)
+   *   4. All operator-type users
+   */
+  resolveTriager(projectId: string): ResolvedAssignee[] {
+    return resolveAssignment(projectId, 'triager');
+  },
+
+  /**
+   * Resolve the approver for a project.
+   * Same priority chain as triager.
+   */
+  resolveApprover(projectId: string): ResolvedAssignee[] {
+    return resolveAssignment(projectId, 'approver');
+  },
+};
+
+// ── Resolution logic ─────────────────────────────────────────────────
+
+function resolveAssignment(projectId: string, assignmentType: AssignmentType): ResolvedAssignee[] {
+  const db = getDrizzle();
+  const assignment = assignmentRepo.getAssignment(projectId, assignmentType);
+
+  if (assignment) {
+    // 1. Explicit user assignment
+    if (assignment.assigneeType === 'user') {
+      const user = db.select().from(users).where(eq(users.id, assignment.assigneeId)).get();
+      if (user) {
+        return [{ type: 'user', id: user.id, name: user.name, displayName: user.displayName }];
+      }
+      console.warn(`[assignments] Stale user assignment for ${projectId}/${assignmentType}: user ${assignment.assigneeId} not found`);
+    }
+
+    // 2. Explicit agent assignment
+    if (assignment.assigneeType === 'agent') {
+      const agent = db.select().from(agents).where(eq(agents.name, assignment.assigneeId)).get();
+      if (agent && isAgentHealthy(agent)) {
+        return [{ type: 'agent', id: agent.id, name: agent.name }];
+      }
+      if (agent) {
+        console.warn(`[assignments] Agent ${assignment.assigneeId} assigned as ${assignmentType} for ${projectId} is not healthy (status: ${agent.status})`);
+      } else {
+        console.warn(`[assignments] Stale agent assignment for ${projectId}/${assignmentType}: agent ${assignment.assigneeId} not found`);
+      }
+    }
+
+    // 3. Role-based assignment — find any healthy agent with this role in the project
+    if (assignment.assigneeType === 'role') {
+      const roleAgents = findHealthyAgentsWithRole(projectId, assignment.assigneeId);
+      if (roleAgents.length > 0) {
+        return roleAgents;
+      }
+      console.warn(`[assignments] No healthy agents with role "${assignment.assigneeId}" found for ${projectId}/${assignmentType}`);
+    }
+  }
+
+  // 4. Fall back to owner assignment
+  const ownerAssignment = assignmentRepo.getAssignment(projectId, 'owner');
+  if (ownerAssignment) {
+    if (ownerAssignment.assigneeType === 'user') {
+      const user = db.select().from(users).where(eq(users.id, ownerAssignment.assigneeId)).get();
+      if (user) {
+        console.log(`[assignments] Falling back to project owner for ${projectId}/${assignmentType}`);
+        return [{ type: 'user', id: user.id, name: user.name, displayName: user.displayName }];
+      }
+    }
+    if (ownerAssignment.assigneeType === 'agent') {
+      const agent = db.select().from(agents).where(eq(agents.name, ownerAssignment.assigneeId)).get();
+      if (agent && isAgentHealthy(agent)) {
+        console.log(`[assignments] Falling back to project owner agent for ${projectId}/${assignmentType}`);
+        return [{ type: 'agent', id: agent.id, name: agent.name }];
+      }
+    }
+  }
+
+  // 5. Final fallback: legacy userProjects owner
+  const legacyOwner = db
+    .select({ id: users.id, name: users.name, displayName: users.displayName })
+    .from(users)
+    .innerJoin(userProjects, eq(users.id, userProjects.userId))
+    .where(and(eq(userProjects.projectId, projectId), eq(userProjects.role, 'owner')))
+    .get();
+  if (legacyOwner) {
+    console.log(`[assignments] Falling back to legacy userProjects owner for ${projectId}/${assignmentType}`);
+    return [{ type: 'user', id: legacyOwner.id, name: legacyOwner.name, displayName: legacyOwner.displayName }];
+  }
+
+  // 6. All operator-type users as last resort
+  const operators = db.select().from(users).where(eq(users.type, 'operator')).all();
+  if (operators.length > 0) {
+    console.log(`[assignments] Falling back to all operators for ${projectId}/${assignmentType}`);
+    return operators.map(u => ({ type: 'user' as const, id: u.id, name: u.name, displayName: u.displayName }));
+  }
+
+  return [];
+}
+
+/**
+ * Find healthy agents assigned to a project that have a given role.
+ */
+function findHealthyAgentsWithRole(projectId: string, role: string): ResolvedAssignee[] {
+  const db = getDrizzle();
+
+  // Get all agents with the target role
+  const allAgents = db
+    .select()
+    .from(agents)
+    .where(eq(agents.role, role))
+    .all();
+
+  const healthy = allAgents.filter(isAgentHealthy);
+  return healthy.map(a => ({ type: 'agent' as const, id: a.id, name: a.name }));
+}
+
+// ── Owner migration (#77) ─────────────────────────────────────────────
+
+/**
+ * One-time migration: promote legacy userProjects owner rows to project_assignments.
+ * Only runs if project_assignments table is empty but userProjects has owners.
+ */
+export function migrateOwnerAssignments(): void {
+  const db = getDrizzle();
+
+  // Check if project_assignments already has any rows
+  const existing = db.select({ id: projectAssignments.id }).from(projectAssignments).limit(1).get();
+  if (existing) {
+    return; // Already seeded, skip
+  }
+
+  // Find all userProjects rows with role = 'owner'
+  const owners = db
+    .select({ userId: userProjects.userId, projectId: userProjects.projectId })
+    .from(userProjects)
+    .where(eq(userProjects.role, 'owner'))
+    .all();
+
+  if (owners.length === 0) {
+    return;
+  }
+
+  console.log(`[assignments] Migrating ${owners.length} owner(s) from userProjects to project_assignments`);
+
+  const now = new Date().toISOString();
+  for (const row of owners) {
+    try {
+      db.insert(projectAssignments).values({
+        id: uuidv4(),
+        projectId: row.projectId,
+        assignmentType: 'owner',
+        assigneeType: 'user',
+        assigneeId: row.userId,
+        createdAt: now,
+        updatedAt: now,
+      }).onConflictDoNothing().run();
+    } catch (err: any) {
+      console.warn(`[assignments] Migration failed for project ${row.projectId}: ${err.message}`);
+    }
+  }
+
+  console.log(`[assignments] Owner migration complete`);
+}

--- a/packages/control/src/repositories/index.ts
+++ b/packages/control/src/repositories/index.ts
@@ -33,3 +33,5 @@ export { usageRepo } from './usage-repo.js';
 export type { UsageEntry, UsageTotals, UsageByDimension, UsagePeriod } from './usage-repo.js';
 export { notificationChannelRepo } from './notification-channel-repo.js';
 export type { NotificationChannel, NotificationChannelType } from './notification-channel-repo.js';
+export { assignmentRepo, migrateOwnerAssignments } from './assignment-repo.js';
+export type { Assignment, AssignmentType, AssigneeType, ResolvedAssignee } from './assignment-repo.js';

--- a/packages/control/src/routes/assignments.ts
+++ b/packages/control/src/routes/assignments.ts
@@ -1,0 +1,169 @@
+/**
+ * Assignment routes — project responsibility assignments (#77)
+ *
+ * GET    /api/projects/:id/assignments          → list all assignments for project
+ * PUT    /api/projects/:id/assignments/:type    → set assignment (upsert)
+ * DELETE /api/projects/:id/assignments/:type    → remove assignment
+ */
+import { Router } from 'express';
+import type { Request } from 'express';
+import { requireScope } from '../middleware/scopes.js';
+import { projectsRepo, assignmentRepo } from '../repositories/index.js';
+import { registerToolDef } from '../utils/tool-registry.js';
+import { logActivity } from '../services/activity-service.js';
+import type { AssignmentType, AssigneeType } from '../repositories/assignment-repo.js';
+
+const VALID_ASSIGNMENT_TYPES: AssignmentType[] = ['triager', 'approver', 'owner'];
+const VALID_ASSIGNEE_TYPES: AssigneeType[] = ['user', 'agent', 'role'];
+
+// Helper to extract merged params (id comes from parent route via mergeParams)
+function getProjectId(req: Request): string {
+  return (req.params as Record<string, string>).id ?? '';
+}
+
+const router = Router({ mergeParams: true });
+
+// ── Tool definitions ─────────────────────────────────────────────────
+
+registerToolDef({
+  name: 'armada_project_assignments_list',
+  description: 'List all responsibility assignments for a project (triager, approver, owner).',
+  method: 'GET',
+  path: '/api/projects/:id/assignments',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID', required: true },
+  ],
+  scope: 'projects:read',
+});
+
+registerToolDef({
+  name: 'armada_project_assignment_set',
+  description: 'Set a responsibility assignment for a project. Assignment types: triager, approver, owner. Assignee types: user, agent, role.',
+  method: 'PUT',
+  path: '/api/projects/:id/assignments/:type',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID', required: true },
+    { name: 'type', type: 'string', description: 'Assignment type: triager | approver | owner', required: true },
+    { name: 'assigneeType', type: 'string', description: 'Assignee type: user | agent | role', required: true },
+    { name: 'assigneeId', type: 'string', description: 'Assignee identifier (user ID, agent name, or role name)', required: true },
+  ],
+  scope: 'projects:write',
+});
+
+registerToolDef({
+  name: 'armada_project_assignment_remove',
+  description: 'Remove a responsibility assignment from a project.',
+  method: 'DELETE',
+  path: '/api/projects/:id/assignments/:type',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID', required: true },
+    { name: 'type', type: 'string', description: 'Assignment type: triager | approver | owner', required: true },
+  ],
+  scope: 'projects:write',
+});
+
+registerToolDef({
+  name: 'armada_project_assignment_resolve',
+  description: 'Resolve the effective assignee for a triager or approver slot, following the full priority chain.',
+  method: 'GET',
+  path: '/api/projects/:id/assignments/:type/resolve',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID', required: true },
+    { name: 'type', type: 'string', description: 'Assignment type: triager | approver', required: true },
+  ],
+  scope: 'projects:read',
+});
+
+// ── Routes ───────────────────────────────────────────────────────────
+
+// GET /api/projects/:id/assignments
+router.get('/', (req, res) => {
+  const projectId = getProjectId(req);
+  const project = projectsRepo.get(projectId) || projectsRepo.getByName(projectId);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  const assignments = assignmentRepo.getAssignmentsForProject(project.id);
+  res.json({ assignments });
+});
+
+// PUT /api/projects/:id/assignments/:type
+router.put('/:type', requireScope('projects:write'), (req, res) => {
+  const projectId = getProjectId(req);
+  const project = projectsRepo.get(projectId) || projectsRepo.getByName(projectId);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const assignmentType = req.params.type as AssignmentType;
+  if (!VALID_ASSIGNMENT_TYPES.includes(assignmentType)) {
+    res.status(400).json({ error: `Invalid assignment type. Must be one of: ${VALID_ASSIGNMENT_TYPES.join(', ')}` });
+    return;
+  }
+
+  const { assigneeType, assigneeId } = req.body;
+  if (!assigneeType || !assigneeId) {
+    res.status(400).json({ error: 'assigneeType and assigneeId are required' });
+    return;
+  }
+  if (!VALID_ASSIGNEE_TYPES.includes(assigneeType as AssigneeType)) {
+    res.status(400).json({ error: `Invalid assigneeType. Must be one of: ${VALID_ASSIGNEE_TYPES.join(', ')}` });
+    return;
+  }
+
+  const assignment = assignmentRepo.setAssignment(project.id, assignmentType, assigneeType as AssigneeType, assigneeId);
+  logActivity({
+    eventType: 'project.assignment.set',
+    detail: `Project "${project.name}" ${assignmentType} set to ${assigneeType}:${assigneeId}`,
+  });
+  res.json({ assignment });
+});
+
+// DELETE /api/projects/:id/assignments/:type
+router.delete('/:type', requireScope('projects:write'), (req, res) => {
+  const projectId = getProjectId(req);
+  const project = projectsRepo.get(projectId) || projectsRepo.getByName(projectId);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const assignmentType = req.params.type as AssignmentType;
+  if (!VALID_ASSIGNMENT_TYPES.includes(assignmentType)) {
+    res.status(400).json({ error: `Invalid assignment type. Must be one of: ${VALID_ASSIGNMENT_TYPES.join(', ')}` });
+    return;
+  }
+
+  assignmentRepo.removeAssignment(project.id, assignmentType);
+  logActivity({
+    eventType: 'project.assignment.removed',
+    detail: `Project "${project.name}" ${assignmentType} assignment removed`,
+  });
+  res.status(204).send();
+});
+
+// GET /api/projects/:id/assignments/:type/resolve
+router.get('/:type/resolve', (req, res) => {
+  const projectId = getProjectId(req);
+  const project = projectsRepo.get(projectId) || projectsRepo.getByName(projectId);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const assignmentType = req.params.type as AssignmentType;
+  if (!['triager', 'approver'].includes(assignmentType)) {
+    res.status(400).json({ error: 'resolve only applies to triager and approver types' });
+    return;
+  }
+
+  const resolved = assignmentType === 'triager'
+    ? assignmentRepo.resolveTriager(project.id)
+    : assignmentRepo.resolveApprover(project.id);
+
+  res.json({ resolved });
+});
+
+export default router;

--- a/packages/control/src/routes/users.ts
+++ b/packages/control/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { requireScope } from '../middleware/scopes.js';
-import { usersRepo, userProjectsRepo } from '../repositories/index.js';
+import { usersRepo, userProjectsRepo, assignmentRepo } from '../repositories/index.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 import { generateAvatar, avatarExists, deleteAvatar, readAvatar, getDefaultAvatarUrl } from '../services/avatar-generator.js';
 import { logActivity } from '../services/activity-service.js';
@@ -178,6 +178,11 @@ router.delete('/:id', requireScope('users:write'), (req, res) => {
   }
   usersRepo.delete(req.params.id);
   deleteAvatar(existing.name, 'user').catch(() => {});
+  // Clean up any project assignments for this user
+  const cleaned = assignmentRepo.removeAssignmentsForAssignee('user', req.params.id);
+  if (cleaned > 0) {
+    console.log(`[users] Cleaned ${cleaned} stale project assignment(s) for deleted user "${existing.name}"`);
+  }
   res.status(204).end();
 });
 

--- a/packages/control/src/services/mutation-executor.ts
+++ b/packages/control/src/services/mutation-executor.ts
@@ -6,6 +6,7 @@ import {
   modelRegistryRepo,
   pluginLibraryRepo,
   instancesRepo,
+  assignmentRepo,
 } from '../repositories/index.js';
 import type { PendingMutation } from '../repositories/pending-mutation-repo.js';
 import { pluginManager } from './plugin-manager.js';
@@ -102,7 +103,15 @@ function executeMutation(mutation: PendingMutation): void {
       } else if (action === 'update' && entityId) {
         agentsRepo.update(entityId, payload as any);
       } else if (action === 'delete' && entityId) {
+        // Capture name before deletion for assignment cleanup
+        const agentToDelete = agentsRepo.getById(entityId);
         agentsRepo.remove(entityId);
+        if (agentToDelete?.name) {
+          const cleaned = assignmentRepo.removeAssignmentsForAssignee('agent', agentToDelete.name);
+          if (cleaned > 0) {
+            console.log(`[mutation-executor] Cleaned ${cleaned} stale assignment(s) for deleted agent "${agentToDelete.name}"`);
+          }
+        }
       }
       break;
 

--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -9,7 +9,7 @@
  * which is then used to start a workflow run.
  */
 
-import { agentsRepo, projectsRepo, roleMetaRepo, tasksRepo, instancesRepo, userProjectsRepo } from '../repositories/index.js';
+import { agentsRepo, projectsRepo, roleMetaRepo, tasksRepo, instancesRepo, userProjectsRepo, assignmentRepo } from '../repositories/index.js';
 import { getDrizzle } from '../db/drizzle.js';
 import { triagedIssues } from '../db/drizzle-schema.js';
 import { and, eq, sql } from 'drizzle-orm';
@@ -107,20 +107,46 @@ export async function triageIssue(
   const project = projectsRepo.get(projectId);
   const projectName = project?.name ?? projectId;
 
-  const pm = resolveProjectManager(projectId);
+  // Try resolveTriager first (explicit assignment → role-based → owner → operators)
+  // then fall back to the legacy PM resolution chain.
+  const triagerCandidates = assignmentRepo.resolveTriager(projectId);
+  const triagerAgent = triagerCandidates.find(c => c.type === 'agent');
+
+  // Also check for PM-tier agent (legacy chain, kept as fallback)
+  const legacyPm = resolveProjectManager(projectId);
+
+  // Prefer explicit triager assignment, fall back to legacy PM
+  const pm = triagerAgent
+    ? { name: triagerAgent.name!, role: 'triager' }
+    : legacyPm;
+
   const workflows = getWorkflowsForProject(projectId).filter(w => w.enabled);
 
   if (!pm) {
-    // No PM — check for project owner, then fall back to operators
-    const reason = 'No PM-tier agent is assigned and running for this project';
+    // No triager or PM — notify owner/operators
+    const reason = 'No triager or PM-tier agent is assigned and running for this project';
     if (shouldNotifyFallback(projectId, issue.number)) {
       // Notify project owner if one exists
       const owner = userProjectsRepo.getOwner(projectId);
       if (owner) {
         import('./user-notifier.js').then(({ deliverToUser }) => {
-          const message = `🔔 **Triage Required**\n\nIssue #${issue.number}: ${issue.title}\nProject: ${projectName}\n\nNo PM agent available. As project owner, please triage this issue manually.\n\nReason: ${reason}`;
+          const message = `🔔 **Triage Required**\n\nIssue #${issue.number}: ${issue.title}\nProject: ${projectName}\n\nNo triager agent available. As project owner, please triage this issue manually.\n\nReason: ${reason}`;
           deliverToUser(owner, message, { event: 'triage.owner_fallback', issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason });
         }).catch((err: Error) => console.error('[triage] Failed to notify owner:', err.message));
+      } else {
+        // Try resolving owner from assignment table
+        const ownerCandidates = assignmentRepo.resolveTriager(projectId).filter(c => c.type === 'user');
+        for (const ownerCandidate of ownerCandidates) {
+          import('./user-notifier.js').then(({ deliverToUser }) => {
+            import('../repositories/index.js').then(({ usersRepo }) => {
+              const ownerUser = usersRepo.getById(ownerCandidate.id);
+              if (ownerUser) {
+                const message = `🔔 **Triage Required**\n\nIssue #${issue.number}: ${issue.title}\nProject: ${projectName}\n\nNo triager agent available. Please triage this issue manually.\n\nReason: ${reason}`;
+                deliverToUser(ownerUser, message, { event: 'triage.owner_fallback', issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason });
+              }
+            }).catch(() => {});
+          }).catch((err: Error) => console.error('[triage] Failed to notify owner candidate:', err.message));
+        }
       }
       // Also notify operators
       notifyTriageOperatorFallback({


### PR DESCRIPTION
Closes #77

## Changes

- New `project_assignments` table with mutex constraint (one triager/approver/owner per project)
- `assignment-repo.ts` with full resolution chain: explicit → role-based → owner → operators
- API endpoints: GET/PUT/DELETE `/api/projects/:id/assignments` + resolve endpoint
- Triage updated to use `resolveTriager()` first, legacy PM fallback kept
- Stale assignment cleanup on agent/user deletion
- Migration from existing `userProjects` owner system on startup
- 413 tests pass, TypeScript compiles clean