### PR TITLE
feat: unified LoadingState component with rocket animation (#79)

### DIFF
--- a/packages/ui/src/components/LoadingState.tsx
+++ b/packages/ui/src/components/LoadingState.tsx
@@ -1,0 +1,82 @@
+import { Rocket } from 'lucide-react';
+
+interface LoadingStateProps {
+  size?: 'sm' | 'lg';
+  message?: string;
+  inline?: boolean;
+}
+
+export function LoadingState({ size = 'lg', message, inline = false }: LoadingStateProps) {
+  if (inline) {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <style>{`
+          @keyframes rocket-float-inline {
+            0%, 100% { transform: translateY(0px); }
+            50% { transform: translateY(-2px); }
+          }
+          .rocket-float-inline {
+            animation: rocket-float-inline 1.4s ease-in-out infinite;
+          }
+        `}</style>
+        <Rocket className="rocket-float-inline w-3.5 h-3.5 text-violet-400" />
+        {message && <span className="text-zinc-400 text-sm">{message}</span>}
+      </span>
+    );
+  }
+
+  if (size === 'sm') {
+    return (
+      <div className="flex items-center gap-2">
+        <style>{`
+          @keyframes rocket-float-sm {
+            0%, 100% { transform: translateY(0px) rotate(-45deg); }
+            50% { transform: translateY(-3px) rotate(-45deg); }
+          }
+          .rocket-float-sm {
+            animation: rocket-float-sm 1.4s ease-in-out infinite;
+          }
+          @keyframes trail-fade-sm {
+            0%, 100% { opacity: 0.3; }
+            50% { opacity: 0.7; }
+          }
+          .rocket-trail-sm {
+            animation: trail-fade-sm 1.4s ease-in-out infinite;
+          }
+        `}</style>
+        <div className="relative">
+          <Rocket className="rocket-float-sm w-4 h-4 text-violet-400" />
+          <span className="rocket-trail-sm absolute -bottom-1 -right-1 w-1 h-1 bg-violet-400/50 rounded-full blur-sm" />
+        </div>
+        {message && <span className="text-zinc-400 text-sm">{message}</span>}
+      </div>
+    );
+  }
+
+  // Large (default) — centered in container
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-12">
+      <style>{`
+        @keyframes rocket-float-lg {
+          0%, 100% { transform: translateY(0px) rotate(-45deg); }
+          50% { transform: translateY(-8px) rotate(-45deg); }
+        }
+        .rocket-float-lg {
+          animation: rocket-float-lg 1.6s ease-in-out infinite;
+        }
+        @keyframes trail-pulse {
+          0%, 100% { opacity: 0.2; transform: scale(0.8); }
+          50% { opacity: 0.5; transform: scale(1.2); }
+        }
+        .rocket-trail-lg {
+          animation: trail-pulse 1.6s ease-in-out infinite;
+        }
+      `}</style>
+      <div className="relative">
+        <Rocket className="rocket-float-lg w-8 h-8 text-violet-400" />
+        <span className="rocket-trail-lg absolute -bottom-2 left-1/2 -translate-x-1/2 w-3 h-3 bg-violet-500/40 rounded-full blur-md" />
+      </div>
+      {message && <p className="text-sm text-zinc-400">{message}</p>}
+    </div>
+  );
+}

--- a/packages/ui/src/pages/AcceptInvite.tsx
+++ b/packages/ui/src/pages/AcceptInvite.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Loader2, AlertCircle, UserPlus, CheckCircle } from 'lucide-react';
+import { LoadingState } from '../components/LoadingState';
 import RegisterPasskey from '../components/RegisterPasskey';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -91,7 +92,7 @@ export default function AcceptInvite() {
   if (loading) {
     return (
       <div className="min-h-screen bg-zinc-950 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-violet-500" />
+        <LoadingState />
       </div>
     );
   }

--- a/packages/ui/src/pages/Account.tsx
+++ b/packages/ui/src/pages/Account.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { apiFetch } from '../hooks/useApi';
 import { Shield, Fingerprint, Trash2, User, Key, Lock, Save, Loader2, Bell, Link, Unlink, CheckCircle, MessageCircle } from 'lucide-react';
+import { LoadingState } from '../components/LoadingState';
 import { PageHeader } from '../components/PageHeader';
 import RegisterPasskey from '../components/RegisterPasskey';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -330,9 +331,7 @@ export default function Account() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-violet-500" />
-      </div>
+      <LoadingState message="Loading account…" />
     );
   }
 

--- a/packages/ui/src/pages/AgentDetail.tsx
+++ b/packages/ui/src/pages/AgentDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Loader2, Palette, Hand, Bot, RefreshCw, Trash2, MessageSquare, Settings2 } from 'lucide-react';
+import { ArrowLeft, Palette, Hand, Bot, RefreshCw, Trash2, MessageSquare, Settings2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../hooks/useApi';
@@ -21,6 +21,7 @@ import SessionView from '../components/SessionView';
 import { useSSEEvent } from '../providers/SSEProvider';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../components/ui/table';
+import { LoadingState } from '../components/LoadingState';
 
 interface ConfigDiff {
   key: string;
@@ -341,7 +342,7 @@ export default function AgentDetail() {
   }
 
   if (loading) {
-    return <div className="py-12 text-center text-zinc-500">Loading…</div>;
+    return <LoadingState message="Loading agent…" />;
   }
 
   if (error && !agent) {

--- a/packages/ui/src/pages/ProjectDetail.tsx
+++ b/packages/ui/src/pages/ProjectDetail.tsx
@@ -22,6 +22,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Switch } from '../components/ui/switch';
 import { toast } from 'sonner';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
+import { LoadingState } from '../components/LoadingState';
 
 /* ── Types ─────────────────────────────────────────── */
 
@@ -1047,11 +1048,7 @@ function IntegrationsTab({ projectId }: { projectId: string }) {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="w-6 h-6 text-zinc-500 animate-spin" />
-      </div>
-    );
+    return <LoadingState message="Loading project…" />;
   }
 
   return (
@@ -1301,10 +1298,7 @@ function formatDuration(ms: number | null): string {
 function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
   if (!metrics) {
     return (
-      <div className="text-center py-12">
-        <Loader2 className="w-8 h-8 text-zinc-700 mx-auto animate-spin" />
-        <p className="text-sm text-zinc-500 mt-2">Loading metrics…</p>
-      </div>
+      <LoadingState message="Loading metrics…" />
     );
   }
 

--- a/packages/ui/src/pages/Providers.tsx
+++ b/packages/ui/src/pages/Providers.tsx
@@ -21,6 +21,7 @@ import { Input } from '../components/ui/input';
 import { Switch } from '../components/ui/switch';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../components/ui/responsive-dialog';
 import { toast } from 'sonner';
+import { LoadingState } from '../components/LoadingState';
 
 const PROVIDER_COLORS: Record<string, string> = {
   anthropic: 'bg-violet-500/20 text-violet-300',
@@ -693,9 +694,7 @@ export default function Providers() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="w-8 h-8 border-2 border-violet-500 border-t-transparent rounded-full animate-spin" />
-      </div>
+      <LoadingState message="Loading providers…" />
     );
   }
 

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { useProviders } from '../hooks/queries/useProviders';
 import { useModels } from '../hooks/queries/useModels';
 import { useSSEConnection } from '../providers/SSEProvider';
 import { Settings as SettingsIcon, Tag, Save, Loader2, CheckCircle2, XCircle, Trash2, Radio, Wifi, WifiOff, Image, Globe } from 'lucide-react';
+import { LoadingState } from '../components/LoadingState';
 import { PageHeader } from '../components/PageHeader';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -178,10 +179,7 @@ export default function Settings() {
       />
 
       {loading ? (
-        <div className="flex items-center gap-2 text-zinc-400 text-sm">
-          <Loader2 className="w-4 h-4 animate-spin" />
-          Loading settings…
-        </div>
+        <LoadingState message="Loading settings…" />
       ) : (
         <div className="space-y-8">
           {/* Public URL */}


### PR DESCRIPTION
Closes #79

## Changes

- New `LoadingState` component with Rocket icon float animation + violet glow trail
- Three modes: `lg` (full page), `sm` (compact), `inline`
- Optional `message` prop for contextual text
- Replaced page-level loading spinners across 6 pages:
  - AcceptInvite, Account, Settings, Providers, ProjectDetail, AgentDetail
- Button-level spinners left intact (those stay as Loader2)