### PR TITLE
fix: reliable WS reconnection with fast-fail proxy (#78)

### DIFF
--- a/packages/node/src/gateway/proxy.ts
+++ b/packages/node/src/gateway/proxy.ts
@@ -10,7 +10,7 @@
  */
 
 import http from 'node:http';
-import { sendCommandToControl } from '../ws/connection.js';
+import { sendCommandToControl, isConnected } from '../ws/connection.js';
 
 const GATEWAY_PORT = parseInt(process.env.GATEWAY_PORT ?? '3002', 10);
 
@@ -58,6 +58,13 @@ export function startGatewayProxy(): http.Server {
       }
     }
 
+    // Fail fast if WS is disconnected — return 503 immediately instead of hanging
+    if (!isConnected()) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Node is not connected to control plane. Reconnecting — please retry shortly.' }));
+      return;
+    }
+
     // Read the body
     let body: unknown = undefined;
     const rawBody = await readBody(req).catch(() => Buffer.alloc(0));
@@ -103,8 +110,11 @@ export function startGatewayProxy(): http.Server {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[gateway-proxy] Failed to proxy ${method} ${path}:`, message);
-      res.writeHead(502, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Gateway proxy error', details: message }));
+      // Use 503 for WS disconnection errors so clients know to retry, 502 for other errors
+      const isDisconnected = message.includes('WS disconnected') || message.includes('Not connected');
+      const statusCode = isDisconnected ? 503 : 502;
+      res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: isDisconnected ? 'Node is not connected to control plane. Reconnecting — please retry shortly.' : 'Gateway proxy error', details: message }));
     }
   });
 

--- a/packages/node/src/ws/connection.ts
+++ b/packages/node/src/ws/connection.ts
@@ -15,8 +15,8 @@ const ARMADA_NODE_TOKEN = process.env.ARMADA_NODE_TOKEN ?? '';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const PING_INTERVAL_MS = 30_000;
-const PONG_TIMEOUT_MS = 10_000;
-const BACKOFF_STEPS = [1000, 2000, 4000, 8000, 16000, 32000, 60000];
+const PONG_TIMEOUT_MS = 5_000;
+const BACKOFF_STEPS = [1000, 2000, 4000, 8000, 16000, 30000];
 
 /** Number of consecutive 403 failures before falling back to install token */
 const MAX_SESSION_AUTH_FAILURES = 3;
@@ -53,6 +53,14 @@ export function getWsConnection(): WebSocket | null {
 }
 
 /**
+ * Returns true if the WebSocket connection is currently in OPEN state.
+ * Used by the gateway proxy to return 503 immediately instead of timing out.
+ */
+export function isConnected(): boolean {
+  return ws !== null && ws.readyState === WebSocket.OPEN;
+}
+
+/**
  * Wait for the WebSocket connection to be ready (OPEN state).
  * Returns immediately if already connected, otherwise waits up to timeoutMs.
  */
@@ -76,7 +84,13 @@ export async function sendCommandToControl(
   params: Record<string, unknown>,
   timeoutMs = 30_000,
 ): Promise<unknown> {
-  // If WS exists but still connecting, wait for it
+  // Fail fast if clearly not connected — don't let caller hang on timeout
+  if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+    console.warn(`[ws] sendCommand(${action}): WS not connected (readyState=${ws?.readyState ?? 'null'})`);
+    throw new Error('WS disconnected: control plane unreachable');
+  }
+
+  // If WS exists but still connecting, wait briefly for it
   if (ws && ws.readyState === WebSocket.CONNECTING) {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error('WS connection timeout')), 5000);
@@ -93,7 +107,7 @@ export async function sendCommandToControl(
 
   if (!ws || ws.readyState !== WebSocket.OPEN) {
     console.warn(`[ws] sendCommand(${action}): ws=${!!ws} readyState=${ws?.readyState} (need ${WebSocket.OPEN})`);
-    throw new Error('Not connected to control plane');
+    throw new Error('WS disconnected: control plane unreachable');
   }
 
   const id = randomUUID();
@@ -383,7 +397,8 @@ function stopPing(): void {
 function scheduleReconnect(): void {
   if (reconnectTimer !== null) return;
   const delay = BACKOFF_STEPS[Math.min(reconnectAttempt, BACKOFF_STEPS.length - 1)];
-  console.log(`[ws] Reconnecting in ${delay / 1000}s...`);
+  const nextAttempt = reconnectAttempt + 1;
+  console.log(`[ws] Reconnect attempt ${nextAttempt} in ${delay / 1000}s → ${CONTROL_URL}`);
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
     reconnectAttempt++;


### PR DESCRIPTION
Closes #78

- Export isConnected() for fast health check
- Proxy returns 503 immediately when WS is down (no timeout hangs)
- sendCommandToControl fails fast on CLOSED state
- Pong timeout 10s → 5s, backoff cap 60s → 30s
- 503 vs 502 distinction (disconnection vs backend error)

413 tests pass, TypeScript compiles.