### PR TITLE
fix: deduplicate tool definitions in /api/meta/tools (#72)

### DIFF
--- a/packages/control/src/utils/tool-registry.ts
+++ b/packages/control/src/utils/tool-registry.ts
@@ -36,8 +36,13 @@ const _tools: ToolDefinition[] = [];
 
 /**
  * Register a tool definition. Called by route setup functions.
+ * Skips registration if a tool with the same name is already registered,
+ * preventing duplicates when routes are initialised more than once.
  */
 export function registerToolDef(def: ToolDefinition): void {
+  if (_tools.some(t => t.name === def.name)) {
+    return;
+  }
   _tools.push(def);
 }
 


### PR DESCRIPTION
Closes #72

Root cause: registerToolDef() had no idempotency guard — tools doubled when createApp() ran more than once.

Fix: early-return guard in registerToolDef() if tool name already registered.

413 tests pass, TypeScript compiles.