### PR TITLE
feat: changeset impact detection — auto-apply zero-impact, scope restarts (#83)

### DIFF
--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -586,6 +586,12 @@ export const changesets = sqliteTable('changesets', {
   error: text('error'),
   /** Schema version when this changeset was created — used to detect stale drafts after migrations */
   schemaVersion: integer('schema_version'),
+  /** Impact level calculated at creation time: none | low | medium | high (#83) */
+  impactLevel: text('impact_level').notNull().default('none'),
+  /** JSON array of AffectedResource objects (#83) */
+  affectedResourcesJson: text('affected_resources_json').notNull().default('[]'),
+  /** Whether this changeset requires an agent/instance restart (#83) */
+  requiresRestart: integer('requires_restart').notNull().default(0),
 });
 
 // ── changeset_operations ─────────────────────────────────────────────

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -406,6 +406,15 @@ const migrations: Migration[] = [
       "ALTER TABLE users ADD COLUMN channels_json TEXT NOT NULL DEFAULT '{}'",
     ],
   },
+  {
+    version: 34,
+    description: 'Add impact analysis columns to changesets (#83)',
+    sql: [
+      "ALTER TABLE changesets ADD COLUMN impact_level TEXT NOT NULL DEFAULT 'none'",
+      'ALTER TABLE changesets ADD COLUMN affected_resources_json TEXT NOT NULL DEFAULT \'[]\'',
+      'ALTER TABLE changesets ADD COLUMN requires_restart INTEGER NOT NULL DEFAULT 0',
+    ],
+  },
 ];
 
 /**

--- a/packages/control/src/services/changeset-impact.ts
+++ b/packages/control/src/services/changeset-impact.ts
@@ -1,0 +1,318 @@
+/**
+ * Changeset Impact Analysis (#83)
+ *
+ * Analyses a list of pending mutations and determines how disruptive the changeset is.
+ * Zero-impact changesets are auto-applied; higher-impact ones need review.
+ */
+
+import {
+  agentsRepo,
+  instancesRepo,
+  templatesRepo,
+  modelRegistryRepo,
+} from '../repositories/index.js';
+import type { PendingMutation } from '../repositories/pending-mutation-repo.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type ImpactLevel = 'none' | 'low' | 'medium' | 'high';
+
+export interface AffectedResource {
+  type: string;        // 'agent' | 'template' | 'model' | 'instance' | etc.
+  name: string;
+  reason: string;
+}
+
+export interface ChangesetImpact {
+  impactLevel: ImpactLevel;
+  affectedResources: AffectedResource[];
+  requiresRestart: boolean;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Return the highest of two impact levels */
+function maxImpact(a: ImpactLevel, b: ImpactLevel): ImpactLevel {
+  const order: ImpactLevel[] = ['none', 'low', 'medium', 'high'];
+  return order[Math.max(order.indexOf(a), order.indexOf(b))];
+}
+
+/**
+ * Find agents that are currently running (status 'running').
+ * Returns an array of running agents.
+ */
+function getRunningAgents() {
+  return agentsRepo.getAll().filter(a => a.status === 'running');
+}
+
+/**
+ * Find instances that are currently running.
+ */
+function getRunningInstances() {
+  return instancesRepo.getAll().filter(i => i.status === 'running');
+}
+
+/**
+ * Get all templates that reference a model by name.
+ */
+function templatesUsingModel(modelName: string) {
+  return templatesRepo.getAll().filter(t => {
+    // Check `model` field (default model for the template)
+    if (t.model === modelName) return true;
+    // Check `models` list
+    if (Array.isArray(t.models)) {
+      return t.models.some((m: any) => m.name === modelName || m.model === modelName);
+    }
+    return false;
+  });
+}
+
+/**
+ * Check if any running agents are assigned to one of the given template IDs.
+ */
+function runningAgentsForTemplates(templateIds: string[]): ReturnType<typeof agentsRepo.getAll> {
+  if (templateIds.length === 0) return [];
+  const running = getRunningAgents();
+  return running.filter(a => a.templateId && templateIds.includes(a.templateId));
+}
+
+/**
+ * Check if any running agents are assigned to one of the given instance IDs.
+ */
+function runningAgentsForInstances(instanceIds: string[]): ReturnType<typeof agentsRepo.getAll> {
+  if (instanceIds.length === 0) return [];
+  const running = getRunningAgents();
+  return running.filter(a => instanceIds.includes(a.instanceId));
+}
+
+// ── Core Analysis ────────────────────────────────────────────────────
+
+/**
+ * Analyse a set of pending mutations and return an impact assessment.
+ *
+ * Impact rules:
+ * - Add model/template (nothing references it yet)           → none
+ * - Update template (no running agents on it)                → none
+ * - Update template (running agents on it)                   → medium
+ * - Update template (running agents + restart needed)        → high
+ * - Delete model (unused by any template)                    → none
+ * - Delete model (used by template but no running agents)    → low
+ * - Delete model (used by template with running agents)      → high
+ * - Update agent config (agent is running)                   → medium
+ * - Update agent config (agent is stopped)                   → low
+ * - Delete agent (agent is running)                          → high
+ * - Delete agent (agent is stopped)                          → low
+ * - Any instance-level mutation                              → high
+ */
+export function analyseChangesetImpact(mutations: PendingMutation[]): ChangesetImpact {
+  let impactLevel: ImpactLevel = 'none';
+  const affectedResources: AffectedResource[] = [];
+  let requiresRestart = false;
+
+  for (const m of mutations) {
+    const { entityType, action, entityId, payload } = m;
+    const entityName = payload?.name ?? entityId ?? '(unknown)';
+
+    // ── Model mutations ──────────────────────────────────────────────
+    if (entityType === 'model') {
+      if (action === 'create') {
+        // Adding a new model — nothing references it yet
+        affectedResources.push({ type: 'model', name: entityName, reason: 'New model added (no dependencies)' });
+        // impactLevel stays 'none'
+      } else if (action === 'update' || action === 'delete') {
+        const modelName = payload?.name ?? entityId ?? '';
+        const usingTemplates = templatesUsingModel(modelName);
+
+        if (usingTemplates.length === 0) {
+          // Model exists but no templates reference it
+          affectedResources.push({ type: 'model', name: entityName, reason: `Model ${action}d (no templates reference it)` });
+          impactLevel = maxImpact(impactLevel, 'none');
+        } else {
+          const templateIds = usingTemplates.map(t => t.id);
+          const runningAgents = runningAgentsForTemplates(templateIds);
+
+          if (runningAgents.length === 0) {
+            affectedResources.push({
+              type: 'model',
+              name: entityName,
+              reason: `Model ${action}d — referenced by ${usingTemplates.length} template(s) but no running agents`,
+            });
+            impactLevel = maxImpact(impactLevel, 'low');
+          } else {
+            // Running agents depend on this model
+            for (const agent of runningAgents) {
+              affectedResources.push({
+                type: 'agent',
+                name: agent.name,
+                reason: `Running agent uses model "${entityName}" via template`,
+              });
+            }
+            affectedResources.push({ type: 'model', name: entityName, reason: `Model ${action}d with ${runningAgents.length} dependent running agent(s)` });
+            impactLevel = maxImpact(impactLevel, 'high');
+            requiresRestart = true;
+          }
+        }
+      }
+    }
+
+    // ── Template mutations ───────────────────────────────────────────
+    else if (entityType === 'template') {
+      if (action === 'create') {
+        affectedResources.push({ type: 'template', name: entityName, reason: 'New template added (no running agents yet)' });
+        // impactLevel stays 'none'
+      } else if (action === 'update' || action === 'delete') {
+        const templateId = entityId ?? '';
+        const runningAgents = runningAgentsForTemplates([templateId]);
+
+        if (runningAgents.length === 0) {
+          affectedResources.push({ type: 'template', name: entityName, reason: `Template ${action}d (no running agents)` });
+          impactLevel = maxImpact(impactLevel, 'none');
+        } else {
+          for (const agent of runningAgents) {
+            affectedResources.push({
+              type: 'agent',
+              name: agent.name,
+              reason: `Running agent uses template "${entityName}"`,
+            });
+          }
+          affectedResources.push({
+            type: 'template',
+            name: entityName,
+            reason: `Template ${action}d — ${runningAgents.length} running agent(s) affected`,
+          });
+          // Deletion of a template with running agents is high; update is medium
+          const level: ImpactLevel = action === 'delete' ? 'high' : 'medium';
+          impactLevel = maxImpact(impactLevel, level);
+          if (action === 'delete') requiresRestart = true;
+        }
+      }
+    }
+
+    // ── Agent mutations ──────────────────────────────────────────────
+    else if (entityType === 'agent') {
+      if (action === 'create') {
+        affectedResources.push({ type: 'agent', name: entityName, reason: 'New agent added' });
+        impactLevel = maxImpact(impactLevel, 'low');
+      } else if (action === 'update') {
+        const agent = entityId ? agentsRepo.getById(entityId) : null;
+        if (agent?.status === 'running') {
+          affectedResources.push({ type: 'agent', name: agent.name, reason: 'Running agent config updated' });
+          impactLevel = maxImpact(impactLevel, 'medium');
+        } else {
+          affectedResources.push({ type: 'agent', name: agent?.name ?? entityName, reason: 'Stopped agent config updated' });
+          impactLevel = maxImpact(impactLevel, 'low');
+        }
+      } else if (action === 'delete') {
+        const agent = entityId ? agentsRepo.getById(entityId) : null;
+        if (agent?.status === 'running') {
+          affectedResources.push({ type: 'agent', name: agent.name, reason: 'Running agent will be deleted' });
+          impactLevel = maxImpact(impactLevel, 'high');
+          requiresRestart = true;
+        } else {
+          affectedResources.push({ type: 'agent', name: agent?.name ?? entityName, reason: 'Stopped agent will be deleted' });
+          impactLevel = maxImpact(impactLevel, 'low');
+        }
+      }
+    }
+
+    // ── Instance mutations ───────────────────────────────────────────
+    else if (entityType === 'instance') {
+      const instance = entityId ? instancesRepo.getById(entityId) : null;
+      const name = instance?.name ?? payload?.name ?? entityId ?? '(unknown)';
+      if (action === 'create') {
+        affectedResources.push({ type: 'instance', name, reason: 'New instance will be provisioned' });
+        impactLevel = maxImpact(impactLevel, 'medium');
+      } else if (action === 'update') {
+        if (instance?.status === 'running') {
+          affectedResources.push({ type: 'instance', name, reason: 'Running instance config updated' });
+          impactLevel = maxImpact(impactLevel, 'high');
+          requiresRestart = true;
+        } else {
+          affectedResources.push({ type: 'instance', name, reason: 'Stopped instance config updated' });
+          impactLevel = maxImpact(impactLevel, 'medium');
+        }
+      } else if (action === 'delete') {
+        affectedResources.push({ type: 'instance', name, reason: 'Instance will be destroyed' });
+        impactLevel = maxImpact(impactLevel, 'high');
+        requiresRestart = true;
+      }
+    }
+
+    // ── Provider / API key mutations ─────────────────────────────────
+    else if (entityType === 'provider' || entityType === 'api_key') {
+      const runningInstances = getRunningInstances();
+      if (runningInstances.length === 0) {
+        affectedResources.push({ type: entityType, name: entityName, reason: `Provider ${action}d (no running instances)` });
+        impactLevel = maxImpact(impactLevel, 'low');
+      } else {
+        affectedResources.push({
+          type: entityType,
+          name: entityName,
+          reason: `Provider ${action}d — ${runningInstances.length} running instance(s) will need config push`,
+        });
+        impactLevel = maxImpact(impactLevel, 'medium');
+      }
+    }
+
+    // ── Plugin mutations ─────────────────────────────────────────────
+    else if (entityType === 'plugin') {
+      if (action === 'create') {
+        affectedResources.push({ type: 'plugin', name: entityName, reason: 'New plugin added to library' });
+        // impactLevel stays 'none'
+      } else {
+        const runningInstances = getRunningInstances();
+        if (runningInstances.length === 0) {
+          affectedResources.push({ type: 'plugin', name: entityName, reason: `Plugin ${action}d (no running instances)` });
+          impactLevel = maxImpact(impactLevel, 'low');
+        } else {
+          affectedResources.push({
+            type: 'plugin',
+            name: entityName,
+            reason: `Plugin ${action}d — ${runningInstances.length} running instance(s) affected`,
+          });
+          impactLevel = maxImpact(impactLevel, 'medium');
+        }
+      }
+    }
+
+    // ── Catch-all for other entity types ────────────────────────────
+    else {
+      affectedResources.push({ type: entityType, name: entityName, reason: `${entityType} ${action}d` });
+      impactLevel = maxImpact(impactLevel, 'low');
+    }
+  }
+
+  return { impactLevel, affectedResources, requiresRestart };
+}
+
+/**
+ * Get the set of agent IDs that are actually affected by the given mutations.
+ * Used for scoped restarts — only restart agents that need it.
+ */
+export function getAffectedAgentIds(mutations: PendingMutation[]): string[] {
+  const affected = new Set<string>();
+
+  for (const m of mutations) {
+    const { entityType, action, entityId, payload } = m;
+
+    if (entityType === 'agent') {
+      if (entityId) affected.add(entityId);
+    } else if (entityType === 'template') {
+      const templateId = entityId ?? '';
+      const runningAgents = runningAgentsForTemplates([templateId]);
+      for (const a of runningAgents) affected.add(a.id);
+    } else if (entityType === 'model') {
+      const modelName = payload?.name ?? entityId ?? '';
+      const usingTemplates = templatesUsingModel(modelName);
+      const runningAgents = runningAgentsForTemplates(usingTemplates.map(t => t.id));
+      for (const a of runningAgents) affected.add(a.id);
+    } else if (entityType === 'instance') {
+      if (entityId) {
+        const instanceAgents = agentsRepo.getAll().filter(a => a.instanceId === entityId);
+        for (const a of instanceAgents) affected.add(a.id);
+      }
+    }
+  }
+
+  return Array.from(affected);
+}

--- a/packages/control/src/services/changeset-service.ts
+++ b/packages/control/src/services/changeset-service.ts
@@ -14,6 +14,7 @@ import { changesetValidator, type ChangesetValidationResult } from './changeset-
 import { applyChangeset, retryFailedInstances } from './changeset-apply.js';
 import { computeMutationDiffs } from './diff-computer.js';
 import { buildStepsForInstance, dagToSteps } from './step-planner.js';
+import { analyseChangesetImpact } from './changeset-impact.js';
 import type { StateChange, ChangesetPlan, Changeset, ArmadaInstance } from '@coderage-labs/armada-shared';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -77,6 +78,9 @@ function rowToChangeset(row: ChangesetRow): Changeset {
     completedAt: row.completedAt ?? undefined,
     error: row.error ?? undefined,
     schemaVersion: row.schemaVersion ?? undefined,
+    impactLevel: (row.impactLevel ?? 'none') as Changeset['impactLevel'],
+    affectedResources: JSON.parse(row.affectedResourcesJson ?? '[]'),
+    requiresRestart: row.requiresRestart === 1,
   };
 }
 
@@ -289,6 +293,11 @@ export function createChangesetService(): ChangesetService {
       schemaVersion = getCurrentSchemaVersion(getDb());
     } catch { /* non-fatal */ }
 
+    // ── Impact analysis (#83) ──────────────────────────────────────
+    const allMutations = pendingMutationRepo.getAll();
+    const impact = analyseChangesetImpact(allMutations);
+    const isZeroImpact = impact.impactLevel === 'none';
+
     getDrizzle().insert(changesets).values({
       id,
       status: 'draft',
@@ -298,9 +307,33 @@ export function createChangesetService(): ChangesetService {
       createdBy: opts?.createdBy ?? null,
       createdAt: now,
       schemaVersion,
+      impactLevel: impact.impactLevel,
+      affectedResourcesJson: JSON.stringify(impact.affectedResources),
+      requiresRestart: impact.requiresRestart ? 1 : 0,
     }).run();
 
     const changeset = get(id)!;
+
+    // ── Auto-apply zero-impact changesets (#83) ─────────────────────
+    // If nothing has real impact (e.g. just adding a new model), skip review
+    // and apply immediately so operators aren't bothered for low-friction ops.
+    if (isZeroImpact && intraConflicts.filter(c => c.type === 'error').length === 0) {
+      console.log(`[changeset] Auto-approving zero-impact changeset ${id}`);
+      getDrizzle().update(changesets).set({
+        status: 'approved',
+        approvedBy: 'system (auto: zero-impact)',
+        approvedAt: new Date().toISOString(),
+      }).where(eq(changesets.id, id)).run();
+      eventBus.emit('changeset.auto_approved', { changesetId: id, reason: 'zero-impact' });
+      // Apply asynchronously so we don't block the create call
+      Promise.resolve().then(() =>
+        applyChangeset(id, {}, get).catch((err: Error) => {
+          console.error(`[changeset] Auto-apply failed for zero-impact changeset ${id}: ${err.message}`);
+        })
+      );
+      const autoApproved = get(id)!;
+      return autoApproved;
+    }
 
     // Attach warnings to result (informational — does not block creation)
     if (intraConflicts.length > 0) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -723,6 +723,16 @@ export interface ChangesetPlan {
   approvedConfigVersion?: number;
 }
 
+// ── Changeset Impact Analysis (#83) ────────────────────────────────
+
+export type ImpactLevel = 'none' | 'low' | 'medium' | 'high';
+
+export interface AffectedResource {
+  type: string;
+  name: string;
+  reason: string;
+}
+
 export interface Changeset {
   id: string;
   status: 'draft' | 'approved' | 'applying' | 'completed' | 'failed' | 'rolled_back' | 'cancelled';
@@ -738,6 +748,12 @@ export interface Changeset {
   error?: string;
   /** Schema version when this changeset was created — stale if current version is higher */
   schemaVersion?: number;
+  /** Impact level: none | low | medium | high (#83) */
+  impactLevel?: ImpactLevel;
+  /** Resources affected by this changeset (#83) */
+  affectedResources?: AffectedResource[];
+  /** Whether any agents/instances need to restart (#83) */
+  requiresRestart?: boolean;
 }
 
 // ── Changeset Conflict Resolution (#320) ───────────────────────────

--- a/packages/ui/src/components/changeset/ImpactBadge.tsx
+++ b/packages/ui/src/components/changeset/ImpactBadge.tsx
@@ -1,0 +1,157 @@
+/**
+ * ImpactBadge — displays the impact level of a changeset (#83)
+ *
+ * Colour key:
+ *   none   → green  (auto-applied, no disruption)
+ *   low    → blue   (minor, no restarts)
+ *   medium → amber  (config push needed)
+ *   high   → red    (restarts required)
+ */
+
+import type { ComponentType } from 'react';
+import type { ImpactLevel, AffectedResource } from '@coderage-labs/armada-shared';
+import { AlertTriangle, CheckCircle, Info, Zap, RefreshCw } from 'lucide-react';
+
+// ── Colour maps ──────────────────────────────────────────────────────
+
+const IMPACT_STYLES: Record<ImpactLevel, { badge: string; dot: string; icon: ComponentType<{ className?: string; title?: string }>; label: string }> = {
+  none: {
+    badge: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+    dot: 'bg-emerald-500',
+    icon: CheckCircle,
+    label: 'Zero impact',
+  },
+  low: {
+    badge: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+    dot: 'bg-blue-500',
+    icon: Info,
+    label: 'Low impact',
+  },
+  medium: {
+    badge: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+    dot: 'bg-amber-500',
+    icon: Zap,
+    label: 'Medium impact',
+  },
+  high: {
+    badge: 'bg-red-500/15 text-red-400 border-red-500/30',
+    dot: 'bg-red-500',
+    icon: AlertTriangle,
+    label: 'High impact',
+  },
+};
+
+// ── ImpactBadge ──────────────────────────────────────────────────────
+
+interface ImpactBadgeProps {
+  impactLevel: ImpactLevel;
+  requiresRestart?: boolean;
+  compact?: boolean;
+}
+
+export function ImpactBadge({ impactLevel, requiresRestart, compact = false }: ImpactBadgeProps) {
+  const style = IMPACT_STYLES[impactLevel] ?? IMPACT_STYLES.low;
+  const Icon = style.icon;
+
+  if (compact) {
+    return (
+      <span
+        className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${style.badge}`}
+        title={style.label}
+      >
+        <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+        {style.label}
+        {requiresRestart && (
+          <RefreshCw className="w-2.5 h-2.5 ml-0.5" title="Requires restart" />
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${style.badge}`}
+    >
+      <Icon className="w-3 h-3" />
+      {style.label}
+      {requiresRestart && (
+        <span className="flex items-center gap-0.5 ml-0.5 opacity-80">
+          <RefreshCw className="w-2.5 h-2.5" />
+          <span className="text-[10px]">restart</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ── AffectedResourcesList ────────────────────────────────────────────
+
+interface AffectedResourcesListProps {
+  resources: AffectedResource[];
+  requiresRestart?: boolean;
+}
+
+const RESOURCE_TYPE_ICONS: Record<string, string> = {
+  agent: '🤖',
+  template: '📋',
+  model: '🧠',
+  instance: '🖥️',
+  provider: '🔌',
+  api_key: '🔑',
+  plugin: '🧩',
+};
+
+export function AffectedResourcesList({ resources, requiresRestart }: AffectedResourcesListProps) {
+  if (!resources || resources.length === 0) return null;
+
+  // Group by type
+  const grouped = resources.reduce<Record<string, AffectedResource[]>>((acc, r) => {
+    const list = acc[r.type] ?? [];
+    list.push(r);
+    acc[r.type] = list;
+    return acc;
+  }, {});
+
+  const restartingAgents = resources.filter(r => r.type === 'agent');
+
+  return (
+    <div className="space-y-2">
+      {/* Restart warning */}
+      {requiresRestart && restartingAgents.length > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+          <RefreshCw className="w-3.5 h-3.5 text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-400">
+            This change will restart{' '}
+            <strong>{restartingAgents.length} agent{restartingAgents.length !== 1 ? 's' : ''}</strong>
+            {': '}
+            {restartingAgents.slice(0, 3).map(a => a.name).join(', ')}
+            {restartingAgents.length > 3 ? ` and ${restartingAgents.length - 3} more` : ''}
+          </p>
+        </div>
+      )}
+
+      {/* Resource groups */}
+      <div className="space-y-1.5">
+        {Object.entries(grouped).map(([type, items]) => (
+          <div key={type} className="space-y-0.5">
+            <div className="text-[10px] text-zinc-500 uppercase tracking-wider flex items-center gap-1">
+              <span>{RESOURCE_TYPE_ICONS[type] ?? '📦'}</span>
+              <span>{type.replace('_', ' ')}s</span>
+              <span className="text-zinc-600">({items.length})</span>
+            </div>
+            {items.map((r, i) => (
+              <div key={i} className="flex items-start gap-2 text-xs text-zinc-400 pl-2">
+                <span className="text-zinc-500 shrink-0">·</span>
+                <span>
+                  <span className="text-zinc-300 font-medium">{r.name}</span>
+                  {' — '}
+                  <span className="text-zinc-500">{r.reason}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/changeset/index.ts
+++ b/packages/ui/src/components/changeset/index.ts
@@ -7,3 +7,4 @@ export { InstanceOpRow } from './InstanceOpRow';
 export type { InstanceOp } from './InstanceOpRow';
 export { ChangesetActions } from './ChangesetActions';
 export { ChangesetSummary, ChangesetSummaryLine, relativeTime } from './ChangesetSummary';
+export { ImpactBadge, AffectedResourcesList } from './ImpactBadge';

--- a/packages/ui/src/pages/Changesets.tsx
+++ b/packages/ui/src/pages/Changesets.tsx
@@ -8,6 +8,8 @@ import {
   MutationsList,
   InstanceOpRow,
   ChangesetActions,
+  ImpactBadge,
+  AffectedResourcesList,
   relativeTime,
 } from '../components/changeset';
 import type { Changeset } from '@coderage-labs/armada-shared';
@@ -84,9 +86,17 @@ function ChangesetRow({ cs, onRefresh }: { cs: Changeset; onRefresh: () => void 
           <StatusBadge status={cs.status} />
         </TableCell>
 
-        {/* Summary: changes / instances / restarts */}
+        {/* Summary: impact badge + changes / instances / restarts */}
         <TableCell className="hidden sm:table-cell">
           <div className="flex items-center gap-3 flex-wrap">
+            {/* Impact badge (#83) */}
+            {cs.impactLevel && (
+              <ImpactBadge
+                impactLevel={cs.impactLevel}
+                requiresRestart={cs.requiresRestart}
+                compact
+              />
+            )}
             {totalChanges > 0 && (
               <span className="text-xs">
                 <span className="text-zinc-300">{totalChanges}</span>{' '}
@@ -104,7 +114,7 @@ function ChangesetRow({ cs, onRefresh }: { cs: Changeset; onRefresh: () => void 
                 {totalRestarts} restart{totalRestarts !== 1 ? 's' : ''}
               </span>
             )}
-            {totalChanges === 0 && totalInstances === 0 && (
+            {totalChanges === 0 && totalInstances === 0 && !cs.impactLevel && (
               <span className="text-xs text-zinc-600">—</span>
             )}
           </div>
@@ -165,6 +175,27 @@ function ChangesetRow({ cs, onRefresh }: { cs: Changeset; onRefresh: () => void 
                 <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2">
                   <XCircle className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
                   <p className="text-xs text-red-400">{cs.error}</p>
+                </div>
+              )}
+
+              {/* Impact analysis (#83) */}
+              {cs.impactLevel && (cs.status === 'draft' || cs.status === 'approved') && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="text-[10px] text-zinc-500 uppercase tracking-wider">Impact</div>
+                    <ImpactBadge impactLevel={cs.impactLevel} requiresRestart={cs.requiresRestart} />
+                    {cs.impactLevel === 'none' && (
+                      <span className="text-[11px] text-emerald-500/80">Auto-applying…</span>
+                    )}
+                  </div>
+                  {cs.affectedResources && cs.affectedResources.length > 0 && (
+                    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 px-3 py-2">
+                      <AffectedResourcesList
+                        resources={cs.affectedResources}
+                        requiresRestart={cs.requiresRestart}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
 


### PR DESCRIPTION
Closes #83

## Changes

- New `changeset-impact.ts` service — analyses mutations, classifies impact level
- Zero-impact changesets auto-apply immediately (no review needed)
- `getAffectedAgentIds()` for scoped restarts (only restart affected agents)
- Schema migration: `impact_level`, `affected_resources_json`, `requires_restart` on changesets table
- API responses include impact data
- UI: ImpactBadge (colour-coded) + AffectedResourcesList components
- Shared types for ImpactLevel and AffectedResource

Impact rules:
- Add model/template → none (auto-apply)
- Update template with running agents → medium/high
- Delete model used by running agents → high
- Update agent config → medium
- Delete agent → high