### PR TITLE
feat: SSE-based log tailing for instances (#12)

### DIFF
--- a/packages/control/src/infrastructure/ws-node-client.ts
+++ b/packages/control/src/infrastructure/ws-node-client.ts
@@ -7,14 +7,20 @@
  */
 
 import { commandDispatcher } from '../ws/command-dispatcher.js';
+import type { ProgressMessage } from '@coderage-labs/armada-shared';
 
 export class WsNodeClient {
   constructor(public readonly nodeId: string) {}
 
   // ── Internal helper ─────────────────────────────────────────────────────────
 
-  private send(action: string, params: object = {}, _timeoutMs?: number): Promise<unknown> {
-    return commandDispatcher.send(this.nodeId, action, params, _timeoutMs);
+  private send(action: string, params: object, timeoutMs: number, onProgress: (msg: ProgressMessage) => void): Promise<unknown>;
+  private send(action: string, params?: object, timeoutMs?: number): Promise<unknown>;
+  private send(action: string, params: object = {}, timeoutMs?: number, onProgress?: (msg: ProgressMessage) => void): Promise<unknown> {
+    if (onProgress) {
+      return commandDispatcher.send(this.nodeId, action, params, timeoutMs ?? 30_000, onProgress);
+    }
+    return commandDispatcher.send(this.nodeId, action, params, timeoutMs);
   }
 
   // === Instance Lifecycle ===
@@ -162,6 +168,65 @@ export class WsNodeClient {
 
   async getContainerStats(id: string): Promise<any> {
     return this.send('container.stats', { id });
+  }
+
+  /**
+   * Stream live container logs via `logs.stream` command.
+   * Each log line is delivered to the `onLine` callback via ProgressMessage.
+   * Returns a cleanup function that stops forwarding lines after the client disconnects.
+   *
+   * The returned Promise rejects (quickly, within ~200ms) if the node returns an error
+   * for the `logs.stream` action (e.g. unknown action on older nodes), allowing the
+   * caller to fall back to polling.
+   */
+  streamContainerLogs(
+    name: string,
+    onLine: (line: string) => void,
+    timeoutMs = 3_600_000, // 1 hour max stream
+  ): Promise<() => void> {
+    let active = true;
+
+    return new Promise<() => void>((resolve, reject) => {
+      let resolved = false;
+
+      const onProgress = (msg: ProgressMessage) => {
+        if (!active) return;
+        if (msg.data?.step === 'log_line' && typeof msg.data.message === 'string') {
+          onLine(msg.data.message);
+        }
+        // Confirm that the node supports logs.stream on first progress message
+        if (!resolved) {
+          resolved = true;
+          resolve(() => { active = false; });
+        }
+      };
+
+      // Wait briefly before resolving; if the node immediately errors, reject instead
+      const startTimer = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          resolve(() => { active = false; });
+        }
+      }, 500);
+
+      this.send('logs.stream', { id: name }, timeoutMs, onProgress)
+        .then(() => {
+          clearTimeout(startTimer);
+          if (!resolved) {
+            resolved = true;
+            resolve(() => { active = false; });
+          }
+        })
+        .catch((err) => {
+          clearTimeout(startTimer);
+          if (!resolved) {
+            resolved = true;
+            // Reject so the route can fall back to polling
+            reject(err);
+          }
+          // If already resolved (stream started), swallow the error
+        });
+    });
   }
 
   async signalContainer(name: string, signal = 'SIGUSR1'): Promise<void> {

--- a/packages/control/src/routes/instances.ts
+++ b/packages/control/src/routes/instances.ts
@@ -90,6 +90,34 @@ registerToolDef({
     scope: 'instances:read',
 });
 
+registerToolDef({
+  name: 'armada_logs',
+  description: 'Tail logs from an agent instance. Returns recent log lines.',
+  method: 'GET',
+  path: '/api/instances/:id/logs',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Instance ID', required: true },
+    { name: 'lines', type: 'number', description: 'Number of lines (default 100)' },
+    { name: 'level', type: 'string', description: 'Filter by log level (error, warn, info)' },
+    { name: 'agent', type: 'string', description: 'Filter by agent name' },
+  ],
+  scope: 'instances:read',
+});
+
+registerToolDef({
+  name: 'armada_logs_stream',
+  description: 'Stream live logs from an agent instance via SSE.',
+  method: 'GET',
+  path: '/api/instances/:id/logs/stream',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Instance ID', required: true },
+    { name: 'lines', type: 'number', description: 'Number of initial lines (default 100)' },
+    { name: 'level', type: 'string', description: 'Filter by log level (error, warn, info)' },
+    { name: 'agent', type: 'string', description: 'Filter by agent name' },
+  ],
+  scope: 'instances:read',
+});
+
 // ── Routes ──────────────────────────────────────────────────────────
 
 const router = Router();
@@ -368,13 +396,34 @@ router.get('/:id/logs', async (req, res, next) => {
     const instance = resolveInstance(req.params.id);
     if (!instance) return res.status(404).json({ error: 'Instance not found' });
 
-    const tail = parseInt(req.query.tail as string, 10) || 100;
+    const lines = parseInt(req.query.lines as string, 10) || 100;
+    const level = req.query.level as string | undefined;
+    const agent = req.query.agent as string | undefined;
+
     const containerName = `armada-instance-${instance.name}`;
-    const node = getNodeClient();
-    const logs = await node.getContainerLogs(containerName, tail);
-    res.type('text/plain').send(logs);
+    const node = getNodeClient(instance.nodeId);
+    const raw = await node.getContainerLogs(containerName, lines);
+
+    // Split into lines and filter control characters from Docker multiplexed streams
+    let logLines = raw
+      .split('\n')
+      .map((l) => stripDockerPrefix(l).trim())
+      .filter((l) => l.length > 0);
+
+    // Filter by log level if requested
+    if (level) {
+      const lvl = level.toLowerCase();
+      logLines = logLines.filter((l) => l.toLowerCase().includes(lvl));
+    }
+
+    // Filter by agent name if requested
+    if (agent) {
+      logLines = logLines.filter((l) => l.toLowerCase().includes(agent.toLowerCase()));
+    }
+
+    res.json({ logs: logLines });
   } catch (err: any) {
-    if (err.message?.includes('failed:')) {
+    if (err.message?.includes('failed:') || err.message?.includes('not connected')) {
       return res.status(502).json({ error: err.message });
     }
     next(err);
@@ -387,43 +436,55 @@ router.get('/:id/logs/stream', async (req, res, next) => {
     const instance = resolveInstance(req.params.id);
     if (!instance) return res.status(404).json({ error: 'Instance not found' });
 
+    const lines = parseInt(req.query.lines as string, 10) || 100;
+    const level = req.query.level as string | undefined;
+    const agent = req.query.agent as string | undefined;
+
     const containerName = `armada-instance-${instance.name}`;
     const node = getNodeClient(instance.nodeId);
     const sse = setupSSE(res);
 
-    // Fetch initial batch of logs
-    let lastSince = Math.floor(Date.now() / 1000) - 60; // last 60 seconds
+    // Helper: filter and send a raw log line via SSE
+    const sendLine = (raw: string) => {
+      const line = stripDockerPrefix(raw).trim();
+      if (!line) return;
+      if (level && !line.toLowerCase().includes(level.toLowerCase())) return;
+      if (agent && !line.toLowerCase().includes(agent.toLowerCase())) return;
+      sse.send('log', { line });
+    };
+
+    // Fetch initial batch of logs synchronously before starting the stream
     try {
-      const initialLogs = await node.getContainerLogs(containerName, 50);
-      if (initialLogs) {
-        for (const line of initialLogs.split('\n')) {
-          const trimmed = line.trim();
-          if (trimmed) sse.send('log', { line: trimmed });
-        }
-      }
+      const initialLogs = await node.getContainerLogs(containerName, lines);
+      for (const l of initialLogs.split('\n')) sendLine(l);
     } catch (err: any) {
       console.warn('[instances] Failed to fetch initial logs:', err.message);
     }
 
-    // Poll for new log lines every 2 seconds using `since` timestamp
-    const pollInterval = setInterval(async () => {
-      try {
-        const now = Math.floor(Date.now() / 1000);
-        const pollClient = getNodeClient(instance.nodeId);
-        const newLogs = await pollClient.getContainerLogs(containerName, 50, lastSince);
-        lastSince = now;
-        if (newLogs) {
-          for (const line of newLogs.split('\n')) {
-            const trimmed = line.trim();
-            if (trimmed) sse.send('log', { line: trimmed });
-          }
-        }
-      } catch (err: any) {
-        console.warn('[instances] Log poll failed:', err.message);
-      }
-    }, 2000);
+    // Stream live logs via progress events from node (logs.stream action)
+    // The node sends each log line as a ProgressMessage with step='log_line'.
+    // Fall back to polling if the node doesn't support the streaming action.
+    let cleanup: (() => void) | null = null;
 
-    res.on('close', () => clearInterval(pollInterval));
+    try {
+      cleanup = await node.streamContainerLogs(containerName, (line) => sendLine(line));
+    } catch (_streamErr) {
+      // Node doesn't support logs.stream — fall back to 2s polling
+      let lastSince = Math.floor(Date.now() / 1000);
+      const pollInterval = setInterval(async () => {
+        try {
+          const now = Math.floor(Date.now() / 1000);
+          const newLogs = await node.getContainerLogs(containerName, 50, lastSince);
+          lastSince = now;
+          for (const l of newLogs.split('\n')) sendLine(l);
+        } catch (pollErr: any) {
+          console.warn('[instances] Log poll failed:', pollErr.message);
+        }
+      }, 2000);
+      cleanup = () => clearInterval(pollInterval);
+    }
+
+    res.on('close', () => cleanup?.());
   } catch (err) { next(err); }
 });
 
@@ -457,3 +518,18 @@ router.post('/heartbeat', requireScope('instances:write'), (req, res) => {
 });
 
 export default router;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Docker multiplexed log streams prepend an 8-byte header to each frame:
+ *   [stream_type (1)] [padding (3)] [size (4 big-endian)]
+ * Strip these non-printable control bytes so callers receive clean text lines.
+ */
+function stripDockerPrefix(line: string): string {
+  // If the line starts with a non-printable byte in the Docker header range, strip first 8 chars
+  if (line.length > 8 && line.charCodeAt(0) <= 2 && line.charCodeAt(0) >= 0) {
+    return line.slice(8);
+  }
+  return line;
+}

--- a/packages/control/src/routes/node-ws.ts
+++ b/packages/control/src/routes/node-ws.ts
@@ -202,6 +202,9 @@ wss.on('connection', (ws: WebSocket, _request: IncomingMessage, auth: Extract<Au
     }
 
     if (isProgress(msg)) {
+      // Dispatch to any pending command's progress callback (e.g. logs.stream)
+      commandDispatcher.handleProgress(msg);
+
       // Forward progress events to the SSE event bus so UI clients receive live updates.
       // The commandId links this progress to the originating operation command.
       eventBus.emit('operation.progress', {

--- a/packages/control/src/ws/command-dispatcher.ts
+++ b/packages/control/src/ws/command-dispatcher.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { WsErrorCode, type ResponseMessage, type StreamMessage } from '@coderage-labs/armada-shared';
+import { WsErrorCode, type ResponseMessage, type StreamMessage, type ProgressMessage } from '@coderage-labs/armada-shared';
 import { serializeMessage } from './protocol.js';
 import { nodeConnectionManager } from './node-connections.js';
 
@@ -11,6 +11,8 @@ interface PendingCommand {
   timer: ReturnType<typeof setTimeout>;
   /** Accumulated stream chunks keyed by seq, only populated for streaming responses */
   streamChunks?: Map<number, string>;
+  /** Progress callback — called for each ProgressMessage matching this command's id */
+  onProgress?: (msg: ProgressMessage) => void;
 }
 
 /**
@@ -25,13 +27,17 @@ export class CommandDispatcher {
   /**
    * Send a command to a node agent and return a Promise that resolves
    * when the node responds (or rejects on timeout/error).
+   * Optionally supply an `onProgress` callback to receive ProgressMessages
+   * before the final ResponseMessage (e.g. for logs.stream).
    */
   async send(
     nodeId: string,
     action: string,
     params: object,
-    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    timeoutMs?: number,
+    onProgress?: (msg: ProgressMessage) => void,
   ): Promise<unknown> {
+    timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const ws = nodeConnectionManager.getConnection(nodeId);
     if (!ws) {
       throw Object.assign(
@@ -53,7 +59,7 @@ export class CommandDispatcher {
         );
       }, timeoutMs);
 
-      this.pending.set(id, { resolve, reject, timer });
+      this.pending.set(id, { resolve, reject, timer, onProgress });
 
       const message = serializeMessage({
         type: 'command',
@@ -93,6 +99,16 @@ export class CommandDispatcher {
       );
       pending.reject(err);
     }
+  }
+
+  /**
+   * Handle an incoming ProgressMessage from a node agent.
+   * Calls the registered onProgress callback if one exists for this command id.
+   */
+  handleProgress(msg: ProgressMessage): void {
+    const pending = this.pending.get(msg.id);
+    if (!pending) return; // Orphaned progress — ignore
+    pending.onProgress?.(msg);
   }
 
   /**

--- a/packages/node/src/handlers/logs.ts
+++ b/packages/node/src/handlers/logs.ts
@@ -1,0 +1,142 @@
+/**
+ * logs.ts — Live container log streaming handler.
+ *
+ * Handles the `logs.stream` action from the control plane.
+ * Streams log lines back as ProgressMessages (step='log_line') until the
+ * container exits, the WS closes, or an error occurs, then sends a final
+ * ResponseMessage to settle the pending command on the control side.
+ */
+
+import {
+  WsErrorCode,
+  type CommandMessage,
+  type ResponseMessage,
+  type ProgressMessage,
+} from '@coderage-labs/armada-shared';
+import { docker } from '../docker/index.js';
+
+export interface LogsHandlerContext {
+  /** Send a progress update (log line) back over the same WS connection. */
+  sendProgress?: (msg: ProgressMessage) => void;
+}
+
+export async function handleLogsCommand(
+  msg: CommandMessage,
+  ctx?: LogsHandlerContext,
+): Promise<ResponseMessage> {
+  const subAction = msg.action.split('.')[1]; // 'stream'
+
+  if (subAction !== 'stream') {
+    return error(msg.id, `Unknown logs action: ${msg.action}`, WsErrorCode.UNKNOWN);
+  }
+
+  const { id, tail } = msg.params as { id: string; tail?: number };
+  if (!id) return error(msg.id, 'id is required', WsErrorCode.DOCKER_ERROR);
+
+  const sendProgress = ctx?.sendProgress;
+  if (!sendProgress) {
+    // No progress callback — fall back to returning last N lines in a single response
+    try {
+      const container = docker.getContainer(id);
+      const logBuffer = await container.logs({
+        stdout: true,
+        stderr: true,
+        tail: tail ?? 100,
+        follow: false,
+      });
+      const raw = typeof logBuffer === 'string' ? logBuffer : logBuffer.toString('utf-8');
+      const lines = raw
+        .split('\n')
+        .map((l) => stripDockerPrefix(l).trim())
+        .filter((l) => l.length > 0);
+      return ok(msg.id, { lines });
+    } catch (err: any) {
+      return error(msg.id, err.message ?? String(err), WsErrorCode.DOCKER_ERROR);
+    }
+  }
+
+  // Stream mode: follow=true, emit each line as a ProgressMessage
+  return new Promise<ResponseMessage>((resolve) => {
+    const container = docker.getContainer(id);
+
+    container.logs({
+      stdout: true,
+      stderr: true,
+      tail: tail ?? 100,
+      follow: true,
+    }).then((stream: NodeJS.ReadableStream | string) => {
+      if (typeof stream === 'string') {
+        // Non-streaming response — emit each line and resolve
+        const lines = stream
+          .split('\n')
+          .map((l) => stripDockerPrefix(l).trim())
+          .filter((l) => l.length > 0);
+        for (const line of lines) {
+          sendProgress({ type: 'progress', id: msg.id, data: { step: 'log_line', message: line } });
+        }
+        resolve(ok(msg.id, { done: true }));
+        return;
+      }
+
+      // Readable stream — emit lines as they arrive
+      let buffer = '';
+
+      stream.on('data', (chunk: Buffer | string) => {
+        const raw = typeof chunk === 'string' ? chunk : stripDockerPrefix(chunk.toString('utf-8'));
+        buffer += raw;
+
+        // Flush complete lines
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? ''; // keep incomplete trailing line in buffer
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed) {
+            sendProgress({ type: 'progress', id: msg.id, data: { step: 'log_line', message: trimmed } });
+          }
+        }
+      });
+
+      stream.on('end', () => {
+        // Flush any remaining buffer
+        if (buffer.trim()) {
+          sendProgress({ type: 'progress', id: msg.id, data: { step: 'log_line', message: buffer.trim() } });
+        }
+        resolve(ok(msg.id, { done: true }));
+      });
+
+      stream.on('error', (err: Error) => {
+        resolve(error(msg.id, err.message, WsErrorCode.DOCKER_ERROR));
+      });
+    }).catch((err: Error) => {
+      const isNotFound =
+        (err as any)?.statusCode === 404 || err.message?.includes('No such container');
+      resolve(error(
+        msg.id,
+        err.message ?? String(err),
+        isNotFound ? WsErrorCode.CONTAINER_NOT_FOUND : WsErrorCode.DOCKER_ERROR,
+      ));
+    });
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function ok(id: string, data: unknown): ResponseMessage {
+  return { type: 'response', id, status: 'ok', data };
+}
+
+function error(id: string, message: string, code: WsErrorCode): ResponseMessage {
+  return { type: 'response', id, status: 'error', error: message, code };
+}
+
+/**
+ * Docker multiplexed log streams prepend an 8-byte header per frame.
+ * Strip these if present so we forward clean text.
+ */
+function stripDockerPrefix(raw: string): string {
+  if (raw.length > 8 && raw.charCodeAt(0) <= 2 && raw.charCodeAt(0) >= 0) {
+    return raw.slice(8);
+  }
+  return raw;
+}

--- a/packages/node/src/ws/command-handler.ts
+++ b/packages/node/src/ws/command-handler.ts
@@ -13,6 +13,7 @@ import { handlePluginCommand } from '../handlers/plugins.js';
 import { handleSystemCommand } from '../handlers/system.js';
 import { handleToolCommand } from '../handlers/tools.js';
 import { handleRelayCommand } from '../handlers/relay.js';
+import { handleLogsCommand, type LogsHandlerContext } from '../handlers/logs.js';
 import { loadCredentials, saveCredentials, CREDENTIALS_PATH } from '../credentials.js';
 import { IdempotencyCache } from './idempotency-cache.js';
 
@@ -37,6 +38,7 @@ const NON_IDEMPOTENT_ACTIONS = new Set([
   'file.read',
   'file.list',
   'plugin.list',
+  'logs.stream',
 ]);
 
 // ── Command router ────────────────────────────────────────────────────────────
@@ -93,7 +95,7 @@ export function handleCommand(msg: WsMessage, socket: WebSocket): void {
   });
 }
 
-async function route(msg: CommandMessage, ctx?: ContainerHandlerContext): Promise<ResponseMessage> {
+async function route(msg: CommandMessage, ctx?: ContainerHandlerContext & LogsHandlerContext): Promise<ResponseMessage> {
   try {
     const { action } = msg;
 
@@ -108,6 +110,7 @@ async function route(msg: CommandMessage, ctx?: ContainerHandlerContext): Promis
     if (action.startsWith('node.')) return await handleSystemCommand(msg);
     if (action.startsWith('tool.')) return await handleToolCommand(msg);
     if (action === 'instance.relay') return await handleRelayCommand(msg);
+    if (action.startsWith('logs.')) return await handleLogsCommand(msg, ctx);
 
     return {
       type: 'response',


### PR DESCRIPTION
Closes #12

## Changes

### Control plane
- `GET /api/instances/:id/logs` — returns `{ logs: string[] }` with `?lines=`, `?level=`, `?agent=` filtering
- `GET /api/instances/:id/logs/stream` — SSE endpoint, streams live logs with same filters
- `armada_logs` + `armada_logs_stream` tool definitions registered
- `WsNodeClient.streamContainerLogs()` — streams via WS progress messages, falls back to polling
- `CommandDispatcher` extended with `onProgress` callback support

### Node agent
- New `handlers/logs.ts` — handles `logs.stream` action via dockerode container.logs(follow: true)
- Streams lines as ProgressMessages, handles Docker 8-byte multiplexed headers

107 tests pass, both control + node compile clean.