### PR TITLE
cleanup: remove legacy Telegram chat_id and backwards-compat notification code (#95)

### DIFF
--- a/packages/control/src/services/notification-service.ts
+++ b/packages/control/src/services/notification-service.ts
@@ -34,23 +34,16 @@ export interface NotificationPayload {
 
 // ── Channel-specific send helpers ────────────────────────────────────
 
-async function sendTelegram(channel: NotificationChannel, text: string): Promise<void> {
-  const { token, chat_id } = channel.config as { token?: string; chat_id?: string };
-  if (!token || !chat_id) {
-    console.warn(`[notification-service] Telegram channel "${channel.name}" missing token or chat_id`);
+async function sendTelegram(channel: NotificationChannel, _text: string): Promise<void> {
+  const { token } = channel.config as { token?: string };
+  if (!token) {
+    console.warn(`[notification-service] Telegram channel "${channel.name}" missing token`);
     return;
   }
-  const url = `https://api.telegram.org/bot${token}/sendMessage`;
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id, text, parse_mode: 'HTML' }),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    console.error(`[notification-service] Telegram send failed (${resp.status}): ${body}`);
-  }
+  // System-level broadcast via a static chat_id is no longer supported.
+  // Telegram notifications are delivered per-user via user.channels.telegram.platformId
+  // through the user-notifier service. This channel entry only needs a token to indicate
+  // that the Telegram bot is enabled for per-user delivery.
 }
 
 async function sendSlack(channel: NotificationChannel, text: string): Promise<void> {

--- a/packages/control/src/services/telegram-bot.ts
+++ b/packages/control/src/services/telegram-bot.ts
@@ -88,8 +88,7 @@ export async function initTelegramBot(): Promise<void> {
 
       const users = usersRepo.getAll();
       const linked = users.find(u =>
-        u.channels?.telegram?.platformId === telegramUserId ||
-        u.linkedAccounts?.telegram === telegramUserId,
+        u.channels?.telegram?.platformId === telegramUserId,
       );
 
       if (linked) {
@@ -118,8 +117,7 @@ export async function initTelegramBot(): Promise<void> {
 
       const users = usersRepo.getAll();
       const linked = users.find(u =>
-        u.channels?.telegram?.platformId === telegramUserId ||
-        u.linkedAccounts?.telegram === telegramUserId,
+        u.channels?.telegram?.platformId === telegramUserId,
       );
 
       if (linked) {
@@ -147,8 +145,7 @@ export async function initTelegramBot(): Promise<void> {
 
       const users = usersRepo.getAll();
       const user = users.find(u =>
-        u.channels?.telegram?.platformId === telegramUserId ||
-        u.linkedAccounts?.telegram === telegramUserId,
+        u.channels?.telegram?.platformId === telegramUserId,
       );
 
       if (user) {
@@ -192,11 +189,9 @@ export async function initTelegramBot(): Promise<void> {
       const action = parts[1];
 
       // Auth: verify the Telegram user ID matches a linked Armada user
-      // Check both new user.channels field and legacy linkedAccounts.telegram for backwards compat
       const users = usersRepo.getAll();
       const user = users.find(u =>
-        u.channels?.telegram?.platformId === telegramUserId ||
-        u.linkedAccounts?.telegram === telegramUserId,
+        u.channels?.telegram?.platformId === telegramUserId,
       );
 
       if (!user) {

--- a/packages/control/src/services/user-notifier.ts
+++ b/packages/control/src/services/user-notifier.ts
@@ -253,8 +253,7 @@ export async function deliverToUser(
   const deliveries: Promise<void>[] = [];
 
   // Telegram — system channel must be enabled + user must have a linked identity
-  // Backwards compat: fall back to legacy notifications.telegram.chatId
-  const telegramId = userChannels.telegram?.platformId || user.notifications?.telegram?.chatId;
+  const telegramId = userChannels.telegram?.platformId;
   if (enabledTypes.has('telegram') && telegramId) {
     const isGate = payload.event === 'workflow.gate';
     deliveries.push(

--- a/packages/control/src/utils/json-schemas.ts
+++ b/packages/control/src/utils/json-schemas.ts
@@ -87,7 +87,6 @@ export const linkedAccountsSchema = z.object({
 
 export const notificationsSchema = z.object({
   channels: z.array(z.string()),
-  telegram: z.object({ chatId: z.string() }).optional(),
   email: z.object({ address: z.string() }).optional(),
   webhook: z.object({ url: z.string() }).optional(),
   preferences: z.object({

--- a/packages/ui/src/pages/Notifications.tsx
+++ b/packages/ui/src/pages/Notifications.tsx
@@ -44,7 +44,6 @@ interface FieldDef { key: string; label: string; placeholder: string; secret?: b
 const CONFIG_FIELDS: Record<ChannelType, FieldDef[]> = {
   telegram: [
     { key: 'token',   label: 'Bot Token',   placeholder: '123456:ABC-DEF…', secret: true },
-    { key: 'chat_id', label: 'Chat ID',      placeholder: '-1001234567890' },
   ],
   slack: [
     { key: 'webhook_url', label: 'Webhook URL', placeholder: 'https://hooks.slack.com/services/…', secret: true },

--- a/packages/ui/src/pages/Users.tsx
+++ b/packages/ui/src/pages/Users.tsx
@@ -62,7 +62,6 @@ interface UserFormData {
   linkedAccounts: { telegram?: string; github?: string; email?: string; callbackUrl?: string; hooksToken?: string };
   notifications: {
     channels: string[];
-    telegram?: { chatId: string };
     email?: { address: string };
     webhook?: { url: string };
     preferences: { gates: boolean; completions: boolean; failures: boolean; quietHours?: { start: string; end: string } };
@@ -111,7 +110,6 @@ function UserDialog({
         linkedAccounts: { ...user.linkedAccounts } as UserFormData['linkedAccounts'],
         notifications: {
           channels: user.notifications?.channels ?? [],
-          telegram: user.notifications?.telegram,
           email: user.notifications?.email,
           webhook: user.notifications?.webhook,
           preferences: {


### PR DESCRIPTION
Closes #95

Removed all legacy notification identity code:
- notification-service: channel config no longer needs chat_id (only token)
- user-notifier: no more fallback to user.notifications.telegram.chatId
- json-schemas: removed telegram.chatId from notification preferences schema
- Notifications UI: removed chat_id field from Telegram channel form
- Users UI: removed legacy notifications.telegram type
- telegram-bot: removed all linkedAccounts.telegram fallback lookups

All identity now flows through user.channels.telegram.platformId only.
123 tests pass, zero TS errors on both packages.