### PR TITLE
feat: WebSocket relay — stream instance events to control plane (#13)

### DIFF
--- a/packages/control/src/infrastructure/ws-node-client.ts
+++ b/packages/control/src/infrastructure/ws-node-client.ts
@@ -380,4 +380,25 @@ export class WsNodeClient {
   async deleteFile(path: string, recursive = false): Promise<void> {
     await this.send('file.delete', { path, recursive });
   }
+
+  // === Instance event relay ===
+
+  /**
+   * Ask the node agent to start relaying SSE events from the given instance
+   * back to the control plane over the WS tunnel.
+   */
+  async subscribeInstanceEvents(
+    instanceId: string,
+    instanceName: string,
+    containerHostname: string,
+  ): Promise<void> {
+    await this.send('events.subscribe', { instanceId, instanceName, containerHostname });
+  }
+
+  /**
+   * Ask the node agent to stop relaying SSE events from the given instance.
+   */
+  async unsubscribeInstanceEvents(instanceId: string): Promise<void> {
+    await this.send('events.unsubscribe', { instanceId });
+  }
 }

--- a/packages/control/src/routes/instances.ts
+++ b/packages/control/src/routes/instances.ts
@@ -118,6 +118,17 @@ registerToolDef({
   scope: 'instances:read',
 });
 
+registerToolDef({
+  name: 'armada_instance_events',
+  description: 'Stream real-time events from an agent instance via SSE. Events include session activity, tool calls, agent status changes, and heartbeats.',
+  method: 'GET',
+  path: '/api/instances/:id/events/stream',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Instance ID or name', required: true },
+  ],
+  scope: 'instances:read',
+});
+
 // ── Routes ──────────────────────────────────────────────────────────
 
 const router = Router();
@@ -515,6 +526,59 @@ router.post('/heartbeat', requireScope('instances:write'), (req, res) => {
     return res.status(result.status).json({ error: result.error });
   }
   res.json(result);
+});
+
+// ── Instance event stream ─────────────────────────────────────────────
+
+/**
+ * GET /api/instances/:id/events/stream
+ *
+ * SSE stream of real-time events for a specific instance.
+ * Events arrive via the node→control WS relay and are emitted on the eventBus
+ * under the key `instance.<instanceName>.<eventType>`.
+ *
+ * The endpoint also sends a `events.subscribe` command to the node agent so
+ * it starts (or confirms) the SSE relay for this instance.
+ */
+router.get('/:id/events/stream', async (req, res, next) => {
+  try {
+    const instance = resolveInstance(req.params.id);
+    if (!instance) return res.status(404).json({ error: 'Instance not found' });
+
+    const sse = setupSSE(res);
+
+    // Request the node agent to start relaying events for this instance
+    const containerName = `armada-instance-${instance.name}`;
+    try {
+      const node = getNodeClient(instance.nodeId);
+      await node.subscribeInstanceEvents(instance.id, instance.name, containerName);
+    } catch (err: any) {
+      // Non-fatal — if the node doesn't support events yet, we just get no events
+      console.warn(`[instances] events.subscribe failed for ${instance.name}: ${err.message}`);
+    }
+
+    // Subscribe to all event types for this instance from the eventBus
+    const pattern = `instance.${instance.name}.*`;
+    const unsubscribe = eventBus.on(pattern, (armadaEvent) => {
+      sse.send(armadaEvent.event, armadaEvent.data, armadaEvent.id);
+    });
+
+    // Replay recent events from the ring buffer
+    const replayEvents = eventBus.replay(0, pattern);
+    for (const evt of replayEvents) {
+      sse.send(evt.event, evt.data, evt.id);
+    }
+
+    res.on('close', () => {
+      unsubscribe();
+      // Unsubscribe the node agent when no more SSE clients remain for this instance
+      // (simple heuristic: unsubscribe on last client close)
+      const node = getNodeClient(instance.nodeId);
+      node.unsubscribeInstanceEvents(instance.id).catch(() => {
+        // Best-effort — ignore if node is offline
+      });
+    });
+  } catch (err) { next(err); }
 });
 
 export default router;

--- a/packages/control/src/routes/node-ws.ts
+++ b/packages/control/src/routes/node-ws.ts
@@ -259,6 +259,22 @@ wss.on('connection', (ws: WebSocket, _request: IncomingMessage, auth: Extract<Au
         return;
       }
 
+      if (msg.event === 'instance.event' && msg.data) {
+        // An OpenClaw instance event forwarded by the node agent.
+        // Re-emit on the event bus with a namespaced key so SSE clients can filter.
+        const instanceEvent = msg.data as {
+          instanceId?: string;
+          instanceName?: string;
+          eventType?: string;
+          [key: string]: unknown;
+        };
+        const instanceName = instanceEvent.instanceName ?? instanceEvent.instanceId ?? 'unknown';
+        const eventType = instanceEvent.eventType ?? 'unknown';
+        const busKey = `instance.${instanceName}.${eventType}`;
+        eventBus.emit(busKey, { nodeId, ...instanceEvent });
+        return;
+      }
+
       // Other events can be handled here or emitted onto the event bus in future
       return;
     }

--- a/packages/node/src/handlers/events.ts
+++ b/packages/node/src/handlers/events.ts
@@ -1,0 +1,244 @@
+/**
+ * events.ts — Instance event relay handler.
+ *
+ * Connects to a running OpenClaw instance's SSE event stream and forwards
+ * relevant events to the control plane as `EventMessage` payloads over the
+ * existing WS tunnel.
+ *
+ * Architecture:
+ *   Instance (OpenClaw SSE) → Node Agent → EventMessage (WS) → Control Plane
+ *
+ * Subscriptions are lazy: the control plane requests them via `events.subscribe`.
+ * The node only opens an SSE connection when asked to.
+ */
+
+import WebSocket from 'ws';
+import type { EventMessage, InstanceEvent } from '@coderage-labs/armada-shared';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const INSTANCE_PORT = parseInt(process.env.INSTANCE_PORT ?? '18789', 10);
+const SSE_RECONNECT_DELAY_MS = 5_000;
+const SSE_PATH = '/api/events';
+
+/** Event types from instance SSE that we forward to the control plane. */
+const RELAY_EVENTS = new Set([
+  'session.message',
+  'session.tool_call',
+  'agent.status',
+  'heartbeat',
+]);
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+interface InstanceSubscription {
+  instanceId: string;
+  instanceName: string;
+  containerHostname: string;
+  /** AbortController used to cancel the current SSE fetch */
+  abortController: AbortController | null;
+  /** Reconnect timer handle */
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  /** Whether this subscription is still wanted (false = unsubscribed) */
+  active: boolean;
+}
+
+/** Map of instanceId → subscription state */
+const subscriptions = new Map<string, InstanceSubscription>();
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to instance events. Opens an SSE connection to the instance and
+ * forwards events through the WS `socket`. Reconnects automatically on drop.
+ *
+ * @param instanceId     Control-plane instance ID (used as event key)
+ * @param instanceName   Human-readable instance name
+ * @param containerHostname  Docker hostname of the container
+ * @param socket         The WS connection to the control plane
+ */
+export function subscribeToInstanceEvents(
+  instanceId: string,
+  instanceName: string,
+  containerHostname: string,
+  socket: WebSocket,
+): void {
+  // Unsubscribe any existing subscription for this instance first
+  unsubscribeFromInstanceEvents(instanceId);
+
+  const sub: InstanceSubscription = {
+    instanceId,
+    instanceName,
+    containerHostname,
+    abortController: null,
+    reconnectTimer: null,
+    active: true,
+  };
+
+  subscriptions.set(instanceId, sub);
+  console.log(`[events] Subscribing to instance ${instanceName} (${instanceId})`);
+  connectSSE(sub, socket);
+}
+
+/**
+ * Unsubscribe from instance events. Closes the SSE connection and cancels any
+ * pending reconnect.
+ */
+export function unsubscribeFromInstanceEvents(instanceId: string): void {
+  const sub = subscriptions.get(instanceId);
+  if (!sub) return;
+
+  sub.active = false;
+  sub.abortController?.abort();
+  if (sub.reconnectTimer !== null) {
+    clearTimeout(sub.reconnectTimer);
+    sub.reconnectTimer = null;
+  }
+
+  subscriptions.delete(instanceId);
+  console.log(`[events] Unsubscribed from instance ${sub.instanceName} (${instanceId})`);
+}
+
+/**
+ * Unsubscribe from ALL instance event streams. Called on WS disconnect so we
+ * don't accumulate dangling SSE connections.
+ */
+export function unsubscribeAll(): void {
+  for (const instanceId of subscriptions.keys()) {
+    unsubscribeFromInstanceEvents(instanceId);
+  }
+}
+
+// ── SSE connection logic ──────────────────────────────────────────────────────
+
+function connectSSE(sub: InstanceSubscription, socket: WebSocket): void {
+  if (!sub.active) return;
+
+  const url = `http://${sub.containerHostname}:${INSTANCE_PORT}${SSE_PATH}`;
+  const ac = new AbortController();
+  sub.abortController = ac;
+
+  // We use the native fetch API (Node 18+) which supports SSE over streaming body
+  fetch(url, {
+    signal: ac.signal,
+    headers: { Accept: 'text/event-stream' },
+  })
+    .then(async (response) => {
+      if (!response.ok || !response.body) {
+        throw new Error(`SSE connect failed: ${response.status} ${response.statusText}`);
+      }
+
+      console.log(`[events] SSE connected to ${sub.instanceName} at ${url}`);
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (sub.active) {
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (readErr: any) {
+          if (!sub.active || ac.signal.aborted) return; // intentional close
+          throw readErr;
+        }
+
+        if (result.done) break;
+
+        buffer += decoder.decode(result.value, { stream: true });
+
+        // SSE messages are separated by double newlines
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          const event = parseSSEEvent(part);
+          if (event) {
+            maybeForwardEvent(sub, event, socket);
+          }
+        }
+      }
+    })
+    .catch((err: Error) => {
+      if (!sub.active || ac.signal.aborted) return; // intentional — don't reconnect
+      console.warn(`[events] SSE stream error for ${sub.instanceName}: ${err.message}`);
+      scheduleReconnect(sub, socket);
+    });
+}
+
+function scheduleReconnect(sub: InstanceSubscription, socket: WebSocket): void {
+  if (!sub.active) return;
+  console.log(`[events] Reconnecting to ${sub.instanceName} in ${SSE_RECONNECT_DELAY_MS}ms`);
+  sub.reconnectTimer = setTimeout(() => {
+    sub.reconnectTimer = null;
+    if (sub.active) connectSSE(sub, socket);
+  }, SSE_RECONNECT_DELAY_MS);
+}
+
+// ── SSE parsing ───────────────────────────────────────────────────────────────
+
+interface ParsedSSEEvent {
+  event?: string;
+  data?: string;
+  id?: string;
+}
+
+function parseSSEEvent(raw: string): ParsedSSEEvent | null {
+  const lines = raw.split('\n');
+  const result: ParsedSSEEvent = {};
+
+  for (const line of lines) {
+    if (line.startsWith(':')) continue; // comment
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const field = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trimStart();
+    if (field === 'event') result.event = value;
+    else if (field === 'data') result.data = value;
+    else if (field === 'id') result.id = value;
+  }
+
+  // An SSE block must have at least a data line to be meaningful
+  return result.data !== undefined ? result : null;
+}
+
+// ── Event forwarding ──────────────────────────────────────────────────────────
+
+function maybeForwardEvent(
+  sub: InstanceSubscription,
+  sseEvent: ParsedSSEEvent,
+  socket: WebSocket,
+): void {
+  const eventType = sseEvent.event ?? 'message';
+
+  // Filter: only forward relevant event types
+  if (!RELAY_EVENTS.has(eventType)) return;
+
+  // Parse the JSON data payload
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(sseEvent.data ?? '{}') as Record<string, unknown>;
+  } catch {
+    data = { raw: sseEvent.data };
+  }
+
+  const instanceEvent: InstanceEvent = {
+    instanceId: sub.instanceId,
+    instanceName: sub.instanceName,
+    agentName: (data.agentName as string | undefined) ?? (data.agent as string | undefined),
+    eventType,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+
+  const msg: EventMessage = {
+    type: 'event',
+    event: 'instance.event',
+    data: instanceEvent as unknown as Record<string, unknown>,
+    timestamp: instanceEvent.timestamp,
+  };
+
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(msg));
+  }
+}

--- a/packages/node/src/ws/command-handler.ts
+++ b/packages/node/src/ws/command-handler.ts
@@ -14,6 +14,7 @@ import { handleSystemCommand } from '../handlers/system.js';
 import { handleToolCommand } from '../handlers/tools.js';
 import { handleRelayCommand } from '../handlers/relay.js';
 import { handleLogsCommand, type LogsHandlerContext } from '../handlers/logs.js';
+import { subscribeToInstanceEvents, unsubscribeFromInstanceEvents } from '../handlers/events.js';
 import { loadCredentials, saveCredentials, CREDENTIALS_PATH } from '../credentials.js';
 import { IdempotencyCache } from './idempotency-cache.js';
 
@@ -45,6 +46,65 @@ const NON_IDEMPOTENT_ACTIONS = new Set([
 
 export function handleCommand(msg: WsMessage, socket: WebSocket): void {
   if (!isCommand(msg)) return; // ignore non-command messages
+
+  // ── events.subscribe / events.unsubscribe ─────────────────────────────────
+  // These are handled inline (not via route) because they need the socket ref
+  // for forwarding SSE events back to the control plane.
+  if (msg.action === 'events.subscribe') {
+    const { instanceId, instanceName, containerHostname } = msg.params as {
+      instanceId?: string;
+      instanceName?: string;
+      containerHostname?: string;
+    };
+
+    if (!instanceId || !instanceName || !containerHostname) {
+      const response: ResponseMessage = {
+        type: 'response',
+        id: msg.id,
+        status: 'error',
+        error: 'events.subscribe: instanceId, instanceName, and containerHostname are required',
+        code: 'UNKNOWN',
+      };
+      if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(response));
+      return;
+    }
+
+    subscribeToInstanceEvents(instanceId, instanceName, containerHostname, socket);
+    const response: ResponseMessage = {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { subscribed: true, instanceId },
+    };
+    if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(response));
+    return;
+  }
+
+  if (msg.action === 'events.unsubscribe') {
+    const { instanceId } = msg.params as { instanceId?: string };
+
+    if (!instanceId) {
+      const response: ResponseMessage = {
+        type: 'response',
+        id: msg.id,
+        status: 'error',
+        error: 'events.unsubscribe: instanceId is required',
+        code: 'UNKNOWN',
+      };
+      if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(response));
+      return;
+    }
+
+    unsubscribeFromInstanceEvents(instanceId);
+    const response: ResponseMessage = {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { unsubscribed: true, instanceId },
+    };
+    if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(response));
+    return;
+  }
 
   // Skip cache for read-only commands
   if (!NON_IDEMPOTENT_ACTIONS.has(msg.action)) {

--- a/packages/node/src/ws/connection.ts
+++ b/packages/node/src/ws/connection.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { unlinkSync, existsSync } from 'node:fs';
 import type { EventMessage, CommandMessage, ResponseMessage } from '@coderage-labs/armada-shared';
 import { handleCommand } from './command-handler.js';
+import { unsubscribeAll } from '../handlers/events.js';
 import { loadCredentials, saveCredentials, CREDENTIALS_PATH } from '../credentials.js';
 import { getMachineFingerprint } from '../fingerprint.js';
 import { NODE_VERSION, PROTOCOL_VERSION, MIN_CONTROL_VERSION } from '../version.js';
@@ -275,6 +276,11 @@ function onClose(code: number, reason: Buffer): void {
   
   stopHeartbeat();
   stopPing();
+
+  // Cancel all instance SSE subscriptions — they'll be re-established by the
+  // control plane via events.subscribe after reconnect.
+  unsubscribeAll();
+
   scheduleReconnect();
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -419,6 +419,27 @@ export interface ArmadaNodeEnrichedWithResources extends ArmadaNodeEnriched {
   };
 }
 
+// ── Instance Events (WS relay) ──────────────────────────────────────
+
+/**
+ * Represents a single event forwarded from an OpenClaw instance through
+ * the node agent WS tunnel to the control plane.
+ */
+export interface InstanceEvent {
+  /** Control-plane instance ID (from DB) */
+  instanceId: string;
+  /** Human-readable instance name (e.g. 'robin') */
+  instanceName: string;
+  /** Agent name within the instance, if applicable */
+  agentName?: string;
+  /** Dot-separated event type, e.g. 'session.message', 'agent.status', 'heartbeat' */
+  eventType: string;
+  /** Raw event payload from the instance SSE stream */
+  data: Record<string, unknown>;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+}
+
 // ── Activity ────────────────────────────────────────────────────────
 
 export interface ActivityEvent {

--- a/packages/shared/src/ws-protocol.ts
+++ b/packages/shared/src/ws-protocol.ts
@@ -152,6 +152,10 @@ export type CredentialAction =
   | 'credential.issued'   // Control → Node: new session credential issued after install-token auth
   | 'credential.rotate';  // Control → Node: rotate existing session credential
 
+export type EventsAction =
+  | 'events.subscribe'
+  | 'events.unsubscribe';
+
 export type WsAction =
   | ContainerAction
   | FileAction
@@ -159,7 +163,8 @@ export type WsAction =
   | SystemAction
   | RelayAction
   | GatewayAction
-  | CredentialAction;
+  | CredentialAction
+  | EventsAction;
 
 // ── Credential error codes ──────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #13

## Architecture
Instance (OpenClaw SSE) → Node Agent → EventMessage (WS) → Control Plane → eventBus → SSE → UI

## Changes
### Node agent
- New `handlers/events.ts` — subscribes to instance SSE, forwards events as EventMessages
- Lazy subscription via `events.subscribe` / `events.unsubscribe` commands
- Auto-reconnect on SSE drop, filters to relevant event types only

### Control plane
- `GET /api/instances/:id/events/stream` — SSE endpoint for instance events
- WS gateway handler routes forwarded events to eventBus
- `WsNodeClient.subscribeEvents()` / `unsubscribeEvents()`

### Shared
- `InstanceEvent` type added to shared package

123 tests pass, zero TS errors on control + node.