### PR TITLE
feat: simplified control plane install — docker run + install script (#28)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,43 @@ The `armada-agent` plugin handles task execution, heartbeats, progress reporting
 
 ## Quick Start
 
+### Control Plane — One Command
+
+```bash
+docker run -d \
+  --name armada-control \
+  -p 3001:3001 \
+  -v armada-data:/data \
+  --restart unless-stopped \
+  ghcr.io/coderage-labs/armada:latest
+```
+
+That's it. Armada is now running at `http://<your-host>:3001`.
+
+- **`-v armada-data:/data`** — persists the SQLite database and encryption key across restarts/upgrades
+- **Port 3001** — the combined API and UI
+- **First visit** triggers the setup wizard (create your admin account)
+- **Node install** is separate — get the install command from the UI: Nodes → Add Node
+
+#### Or use the install script
+
+```bash
+curl -fsSL http://<your-host>:3001/api/install/control | bash
+```
+
+#### Or use Docker Compose
+
+Download a ready-to-use `docker-compose.yml` (includes optional Cloudflare Tunnel):
+
+```bash
+curl -fsSL http://<your-host>:3001/api/install/compose -o docker-compose.yml
+docker compose up -d
+```
+
+---
+
+### Development Setup
+
 ### Prerequisites
 
 - Node.js 20+

--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -82,6 +82,9 @@ export function createApp(opts: AppOptions): express.Express {
   // ── Public install script endpoint (no auth required) ────────────────
   app.use('/install', installScriptRoutes);
 
+  // ── Control plane install script + compose template (no auth required) ──
+  app.use('/api/install', installScriptRoutes);
+
   app.use('/api', authMiddleware);
 
   // ── Pending overlay — merge pending mutations into GET responses ──

--- a/packages/control/src/routes/install-script.ts
+++ b/packages/control/src/routes/install-script.ts
@@ -4,6 +4,7 @@ import { Router } from 'express';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { registerToolDef } from '../utils/tool-registry.js';
 
 const router = Router();
 
@@ -83,6 +84,103 @@ router.get('/:token', (req, res) => {
     console.error('[install-script] Failed to serve install script:', err);
     res.status(500).send('# Error: Failed to load install script\n');
   }
+});
+
+// ── Control plane install script ─────────────────────────────────────
+
+const CONTROL_INSTALL_SCRIPT = `#!/bin/bash
+# Armada Control Plane Quick Install
+set -e
+echo "🚀 Installing Armada Control Plane..."
+docker pull ghcr.io/coderage-labs/armada:latest
+docker run -d \\
+  --name armada-control \\
+  -p 3001:3001 \\
+  -v armada-data:/data \\
+  --restart unless-stopped \\
+  ghcr.io/coderage-labs/armada:latest
+echo "✅ Armada is running at http://$(hostname -I | awk '{print $1}'):3001"
+echo "   Complete setup at the URL above."
+`;
+
+// GET /api/install/control — serve the control plane install script
+router.get('/control', (_req, res) => {
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.send(CONTROL_INSTALL_SCRIPT);
+});
+
+// ── Docker Compose template ───────────────────────────────────────────
+
+const COMPOSE_TEMPLATE = `# Armada Control Plane — Docker Compose template
+# Usage: docker compose up -d
+#
+# Data is persisted in the "armada-data" named volume.
+# Port 3001: Armada dashboard + API
+# First visit will trigger the setup wizard.
+#
+# For the node install script, visit http://localhost:3001 → Nodes → Add Node.
+
+services:
+  armada-control:
+    image: ghcr.io/coderage-labs/armada:latest
+    container_name: armada-control
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    volumes:
+      - armada-data:/data
+    networks:
+      - armada
+
+  # ── Cloudflare Tunnel (optional) ────────────────────────────────────
+  # Uncomment to expose Armada via a Cloudflare Tunnel.
+  # 1. Create a tunnel at https://one.dash.cloudflare.com → Zero Trust → Tunnels
+  # 2. Copy the tunnel token and replace REPLACE_WITH_YOUR_TUNNEL_TOKEN below.
+  # 3. Point the tunnel's public hostname to http://armada-control:3001
+  #
+  # cloudflare-tunnel:
+  #   image: cloudflare/cloudflared:latest
+  #   container_name: armada-tunnel
+  #   restart: unless-stopped
+  #   command: tunnel --no-autoupdate run
+  #   environment:
+  #     - TUNNEL_TOKEN=REPLACE_WITH_YOUR_TUNNEL_TOKEN
+  #   networks:
+  #     - armada
+  #   depends_on:
+  #     - armada-control
+
+volumes:
+  armada-data:
+
+networks:
+  armada:
+    driver: bridge
+`;
+
+// GET /api/install/compose — serve the docker-compose.yml template
+router.get('/compose', (_req, res) => {
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Content-Disposition', 'attachment; filename="docker-compose.yml"');
+  res.send(COMPOSE_TEMPLATE);
+});
+
+// ── Tool definitions ──────────────────────────────────────────────────
+
+registerToolDef({
+  name: 'armada_install_control',
+  description: 'Get the control plane install script — a shell script that pulls and runs the Armada control plane via Docker',
+  method: 'GET',
+  path: '/api/install/control',
+  parameters: [],
+});
+
+registerToolDef({
+  name: 'armada_install_compose',
+  description: 'Get a docker-compose.yml template for the Armada control plane (includes optional Cloudflare Tunnel)',
+  method: 'GET',
+  path: '/api/install/compose',
+  parameters: [],
 });
 
 export { router as installScriptRoutes };


### PR DESCRIPTION
Closes #28

- `GET /api/install/control` — shell script for one-liner docker run install
- `GET /api/install/compose` — docker-compose.yml template with optional Cloudflare tunnel
- Updated docs/README.md with quick-start section
- Both endpoints public (no auth), tool definitions registered

123 tests pass, zero TS errors.