### PR TITLE
feat: multi-arch Docker images (amd64 + arm64) + OS-aware install (#9)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -56,6 +58,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.control
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/coderage-labs/armada:latest
@@ -75,6 +78,8 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=$(node -p 'require(\"./packages/node/package.json\").version')" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -84,6 +89,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.node
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/coderage-labs/armada-node:latest

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ graph TD
 
 ## Quick Start
 
+> **Supported platforms:** `linux/amd64` (x86-64) and `linux/arm64` (Apple Silicon, Raspberry Pi, AWS Graviton).
+
 ### Docker Compose
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,22 @@ REGISTRY="ghcr.io/coderage-labs"
 ARMADA_NODE_TOKEN="__NODE_TOKEN__"
 CONTROL_URL="__CONTROL_URL__"
 
+# Detect host architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64)
+    PLATFORM="linux/amd64"
+    ;;
+  aarch64|arm64)
+    PLATFORM="linux/arm64"
+    ;;
+  *)
+    echo "❌ Unsupported architecture: $ARCH"
+    echo "   Armada supports linux/amd64 and linux/arm64."
+    exit 1
+    ;;
+esac
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -40,9 +56,10 @@ fi
 
 echo "🚀 Armada Node Installer"
 echo "==========================="
-echo "Version: $ARMADA_VERSION"
-echo "Directory: $ARMADA_DIR"
-echo "Control: $CONTROL_URL"
+echo "Version:      $ARMADA_VERSION"
+echo "Architecture: $PLATFORM"
+echo "Directory:    $ARMADA_DIR"
+echo "Control:      $CONTROL_URL"
 echo ""
 
 # Create data directory for persistence


### PR DESCRIPTION
## Summary

Adds ARM64 support to Docker images and the node install script.

## Changes

### GitHub Actions (`.github/workflows/release-please.yml`)
- Added `docker/setup-qemu-action@v3` before each Docker publish job (enables cross-compilation)
- Added `docker/setup-buildx-action@v3` for multi-platform build support
- Added `platforms: linux/amd64,linux/arm64` to both `build-push-action` steps

### Install Script (`install.sh`)
- Added architecture detection via `uname -m`
- Supports `x86_64`/`amd64` → `linux/amd64` and `aarch64`/`arm64` → `linux/arm64`
- Exits with clear error message on unsupported architectures
- Prints detected platform in the startup banner

### README.md
- Added supported platforms note (amd64 + arm64/Apple Silicon/Raspberry Pi/Graviton)

### Dockerfiles
- No changes required: `node:22-alpine` already supports arm64; `eget.sh` auto-detects architecture; build tools for `better-sqlite3` (`python3 make g++`) already present

## Verification
- `npx tsc --noEmit`: same pre-existing errors as main (UI JSX config, unbuilt plugins) — no regressions
- `VITEST=true npm run test:unit -w packages/control`: **147/147 tests pass**
- CI workflow YAML validated with `js-yaml`

Closes #9