### PR TITLE
fix: normalise manualGate → gate: 'manual' on workflow create/update (#116)

### DIFF
--- a/packages/control/src/infrastructure/__tests__/normalise-steps.test.ts
+++ b/packages/control/src/infrastructure/__tests__/normalise-steps.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { normaliseSteps } from '../../utils/normalise-steps.js';
+
+describe('normaliseSteps', () => {
+  it('converts manualGate: true to gate: "manual"', () => {
+    const steps: any[] = [{ id: 'step-1', type: 'approval', manualGate: true }];
+    normaliseSteps(steps);
+    expect(steps[0].gate).toBe('manual');
+    expect(steps[0]).not.toHaveProperty('manualGate');
+  });
+
+  it('does not override an existing gate when manualGate is also set', () => {
+    const steps = [{ id: 'step-1', gate: 'manual', manualGate: true }];
+    normaliseSteps(steps);
+    expect(steps[0].gate).toBe('manual');
+    expect(steps[0]).not.toHaveProperty('manualGate');
+  });
+
+  it('removes manualGate: false without setting gate', () => {
+    const steps = [{ id: 'step-1', manualGate: false }];
+    normaliseSteps(steps);
+    expect(steps[0]).not.toHaveProperty('manualGate');
+    expect(steps[0]).not.toHaveProperty('gate');
+  });
+
+  it('leaves steps without manualGate untouched', () => {
+    const steps = [{ id: 'step-1', type: 'job' }];
+    normaliseSteps(steps);
+    expect(steps[0]).not.toHaveProperty('gate');
+    expect(steps[0]).not.toHaveProperty('manualGate');
+  });
+
+  it('normalises only steps with manualGate: true in a mixed array', () => {
+    const steps: any[] = [
+      { id: 'a', manualGate: true },
+      { id: 'b', type: 'job' },
+      { id: 'c', manualGate: false },
+    ];
+    normaliseSteps(steps);
+    expect(steps[0].gate).toBe('manual');
+    expect(steps[1]).not.toHaveProperty('gate');
+    expect(steps[2]).not.toHaveProperty('gate');
+  });
+
+  it('returns the mutated array', () => {
+    const steps = [{ id: 'step-1', manualGate: true }];
+    const result = normaliseSteps(steps);
+    expect(result).toBe(steps);
+  });
+});

--- a/packages/control/src/routes/workflows.ts
+++ b/packages/control/src/routes/workflows.ts
@@ -206,6 +206,7 @@ import {
   requestRework,
   getRunContext,
 } from '../services/workflow-engine.js';
+import { normaliseSteps } from '../utils/normalise-steps.js';
 
 const router = Router();
 
@@ -272,6 +273,9 @@ router.post('/', requireScope('workflows:write'), (req, res) => {
     return;
   }
 
+  // Normalise manualGate → gate: 'manual'
+  normaliseSteps(parsedSteps as any[]);
+
   const id = randomUUID();
   const pIds: string[] = parsedProjectIds || (projectId ? [projectId] : []);
   const wf = createWorkflow(id, { name, description, steps: parsedSteps as any[], projectIds: pIds });
@@ -292,6 +296,8 @@ router.put('/:id', requireScope('workflows:write'), (req, res) => {
       res.status(400).json({ error: `Circular dependency detected: ${cycle.join(' → ')}` });
       return;
     }
+    // Normalise manualGate → gate: 'manual'
+    normaliseSteps(parsedSteps);
   }
 
   const parsedProjectIds = projectIds !== undefined ? (parseJsonField<string[]>(projectIds) || []) : undefined;

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -300,7 +300,7 @@ async function advanceRun(
     if (!allDepsMet) continue;
 
     // Check gate
-    if (step.gate === 'manual') {
+    if (step.gate === 'manual' || (step as any).manualGate === true) {
       markStepStatus(stepRun.id, 'waiting_gate');
       if (_notifyFn) {
         // Get previous step output from context

--- a/packages/control/src/utils/normalise-steps.ts
+++ b/packages/control/src/utils/normalise-steps.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalises legacy `manualGate: true` field to the canonical `gate: 'manual'`.
+ * Mutates the array in-place and returns it.
+ */
+export function normaliseSteps(steps: any[]): any[] {
+  for (const step of steps) {
+    if (step.manualGate === true && !step.gate) {
+      step.gate = 'manual';
+    }
+    delete step.manualGate;
+  }
+  return steps;
+}


### PR DESCRIPTION
Closes #116

- New `normaliseSteps()` utility converts `manualGate: true` → `gate: 'manual'`
- Applied on both create and update in workflows route
- Belt-and-braces: engine also checks `manualGate` at evaluation time
- 6 new tests

153 tests pass, zero TS errors.