### PR TITLE
feat: Telegram triage actions — inline buttons to dispatch or mark triaged (#107)

### DIFF
--- a/packages/control/src/services/telegram-bot.ts
+++ b/packages/control/src/services/telegram-bot.ts
@@ -169,7 +169,7 @@ export async function initTelegramBot(): Promise<void> {
       );
     });
 
-    // Handle callback queries (approve/reject/retry buttons)
+    // Handle callback queries (approve/reject/retry buttons, triage actions)
     bot.on('callback_query:data', async (ctx) => {
       const data = ctx.callbackQuery.data;
       const telegramUserId = ctx.from?.id.toString();
@@ -181,12 +181,12 @@ export async function initTelegramBot(): Promise<void> {
 
       // Parse callback data
       const parts = data.split(':');
-      if (parts.length < 3 || parts[0] !== 'gate') {
+      const namespace = parts[0];
+
+      if (parts.length < 3 || (namespace !== 'gate' && namespace !== 'triage')) {
         await ctx.answerCallbackQuery({ text: 'Invalid callback data' });
         return;
       }
-
-      const action = parts[1];
 
       // Auth: verify the Telegram user ID matches a linked Armada user
       const users = usersRepo.getAll();
@@ -200,7 +200,68 @@ export async function initTelegramBot(): Promise<void> {
         return;
       }
 
+      const action = parts[1];
+
       try {
+        // ── Triage actions ──────────────────────────────────────────────────
+        if (namespace === 'triage') {
+          if (action === 'dispatch' && parts.length === 4) {
+            // triage:dispatch:<projectId>:<issueNumber>
+            const projectId = parts[2];
+            const issueNumber = parseInt(parts[3], 10);
+
+            await ctx.answerCallbackQuery({ text: '🔄 Dispatching workflow...' });
+
+            // Dynamic import to avoid circular dependency (triage → user-notifier → telegram-bot)
+            const { triageDispatch } = await import('./triage.js');
+            const { getWorkflowsForProject } = await import('./workflow-engine.js');
+            const workflows = getWorkflowsForProject(projectId).filter((w: any) => w.enabled);
+
+            if (workflows.length === 0) {
+              await ctx.answerCallbackQuery({ text: '❌ No enabled workflows found for this project' });
+              await ctx.reply('❌ No enabled workflows are configured for this project.');
+              return;
+            }
+
+            const firstWorkflow = workflows[0];
+            const result = await triageDispatch({
+              projectId,
+              issueNumber,
+              workflowId: firstWorkflow.id,
+            });
+
+            if (result.error) {
+              await ctx.reply(`❌ Dispatch failed: ${escapeHtml(result.error)}`, { parse_mode: 'HTML' });
+            } else {
+              const originalText = ctx.callbackQuery.message?.text ?? '';
+              await ctx.editMessageText(
+                `${originalText}\n\n🔄 Workflow <b>${escapeHtml(result.workflowName ?? firstWorkflow.name)}</b> dispatched by ${escapeHtml(user.displayName)}`,
+                { parse_mode: 'HTML', reply_markup: undefined },
+              );
+            }
+
+          } else if (action === 'mark' && parts.length === 4) {
+            // triage:mark:<projectId>:<issueNumber>
+            const projectId = parts[2];
+            const issueNumber = parseInt(parts[3], 10);
+
+            const { markIssueTriaged } = await import('./triage.js');
+            markIssueTriaged(projectId, issueNumber);
+
+            const originalText = ctx.callbackQuery.message?.text ?? '';
+            await ctx.editMessageText(
+              `${originalText}\n\n✅ Triaged by ${escapeHtml(user.displayName)}`,
+              { parse_mode: 'HTML', reply_markup: undefined },
+            );
+            await ctx.answerCallbackQuery({ text: '✅ Marked as triaged' });
+
+          } else {
+            await ctx.answerCallbackQuery({ text: 'Unknown triage action' });
+          }
+          return;
+        }
+
+        // ── Gate actions ────────────────────────────────────────────────────
         if (action === 'approve' && parts.length === 4) {
           const [, , runId, stepId] = parts;
           await approveGate(runId, stepId, user.displayName);
@@ -426,4 +487,34 @@ export async function sendPlainNotification(chatId: string, message: string): Pr
   }
 
   await bot.api.sendMessage(chatId, message, { parse_mode: 'HTML' });
+}
+
+/**
+ * Send a triage fallback notification with inline action buttons.
+ * Buttons allow the operator to dispatch a workflow or mark the issue triaged directly from Telegram.
+ */
+export async function sendTriageNotification(
+  chatId: string,
+  message: string,
+  projectId: string,
+  issueNumber: number,
+  issueUrl: string,
+): Promise<void> {
+  if (!bot) {
+    console.warn('[telegram-bot] Bot not initialized, cannot send triage notification');
+    return;
+  }
+
+  const keyboard = new InlineKeyboard()
+    .text('🔄 Run Workflow', `triage:dispatch:${projectId}:${issueNumber}`)
+    .text('✅ Mark Triaged', `triage:mark:${projectId}:${issueNumber}`);
+
+  if (issueUrl) {
+    keyboard.row().url('🔗 View Issue', issueUrl);
+  }
+
+  await bot.api.sendMessage(chatId, message, {
+    parse_mode: 'HTML',
+    reply_markup: keyboard,
+  });
 }

--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -154,6 +154,7 @@ export async function triageIssue(
       notifyTriageOperatorFallback({
         issueNumber: issue.number,
         issueTitle: issue.title,
+        issueUrl: issue.htmlUrl || (issue as any).url || '',
         projectId,
         projectName,
         reason,
@@ -179,6 +180,7 @@ export async function triageIssue(
       notifyTriageOperatorFallback({
         issueNumber: issue.number,
         issueTitle: issue.title,
+        issueUrl: issue.htmlUrl || (issue as any).url || '',
         projectId,
         projectName,
         reason,
@@ -234,7 +236,7 @@ If none of the workflows fit, respond with:
     console.error(`[triage] PM ${pm.name} has no instanceId`);
     const reason = `PM agent "${pm.name}" has no associated instance`;
     if (shouldNotifyFallback(projectId, issue.number)) {
-      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason })
+      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, issueUrl: issue.htmlUrl || (issue as any).url || '', projectId, projectName, reason })
         .catch((err: Error) => console.error('[triage] Failed to send operator fallback notification:', err.message));
     }
     return { triaged: false, by: 'operator' };
@@ -244,7 +246,7 @@ If none of the workflows fit, respond with:
     console.error(`[triage] Instance for PM ${pm.name} has no nodeId`);
     const reason = `PM agent "${pm.name}" instance has no associated node`;
     if (shouldNotifyFallback(projectId, issue.number)) {
-      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason })
+      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, issueUrl: issue.htmlUrl || (issue as any).url || '', projectId, projectName, reason })
         .catch((err: Error) => console.error('[triage] Failed to send operator fallback notification:', err.message));
     }
     return { triaged: false, by: 'operator' };
@@ -276,7 +278,7 @@ If none of the workflows fit, respond with:
       console.error(`[triage] PM ${pm.name} rejected triage task: ${JSON.stringify(resp)}`);
       const reason = `PM agent "${pm.name}" rejected the triage task (HTTP ${status})`;
       if (shouldNotifyFallback(projectId, issue.number)) {
-        notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason })
+        notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, issueUrl: issue.htmlUrl || (issue as any).url || '', projectId, projectName, reason })
           .catch((err: Error) => console.error('[triage] Failed to send operator fallback notification:', err.message));
       }
       return { triaged: false, by: 'operator' };
@@ -306,7 +308,7 @@ If none of the workflows fit, respond with:
     console.error(`[triage] Failed to reach PM ${pm.name}:`, err.message);
     const reason = `Could not reach PM agent "${pm.name}": ${err.message}`;
     if (shouldNotifyFallback(projectId, issue.number)) {
-      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, projectId, projectName, reason })
+      notifyTriageOperatorFallback({ issueNumber: issue.number, issueTitle: issue.title, issueUrl: issue.htmlUrl || (issue as any).url || '', projectId, projectName, reason })
         .catch((notifyErr: Error) => console.error('[triage] Failed to send operator fallback notification:', notifyErr.message));
     }
     return { triaged: false, by: 'operator' };

--- a/packages/control/src/services/user-notifier.ts
+++ b/packages/control/src/services/user-notifier.ts
@@ -15,7 +15,7 @@
 
 import type { ArmadaUser } from '@coderage-labs/armada-shared';
 import { usersRepo, userProjectsRepo, notificationChannelRepo } from '../repositories/index.js';
-import { sendGateNotification, sendPlainNotification } from './telegram-bot.js';
+import { sendGateNotification, sendPlainNotification, sendTriageNotification } from './telegram-bot.js';
 import { sendSlackGateNotification, sendSlackNotification } from './slack-bot.js';
 import { sendDiscordGateNotification, sendDiscordNotification } from './discord-bot.js';
 import { getDrizzle } from '../db/drizzle.js';
@@ -52,6 +52,7 @@ export interface NotifyCompletionOptions {
 export interface NotifyTriageOperatorFallbackOptions {
   issueNumber: number;
   issueTitle: string;
+  issueUrl?: string;
   projectId: string;
   projectName: string;
   reason: string;
@@ -204,7 +205,7 @@ export async function notifyCompletion(opts: NotifyCompletionOptions): Promise<v
  * - Rate-limited: at most one notification per issue (caller responsibility via cooldown map)
  */
 export async function notifyTriageOperatorFallback(opts: NotifyTriageOperatorFallbackOptions): Promise<void> {
-  const { issueNumber, issueTitle, projectId, projectName, reason, excludeUserIds } = opts;
+  const { issueNumber, issueTitle, issueUrl, projectId, projectName, reason, excludeUserIds } = opts;
 
   // Get users assigned to project — only notify project members
   let users = userProjectsRepo.getUsersForProject(projectId);
@@ -231,6 +232,7 @@ export async function notifyTriageOperatorFallback(opts: NotifyTriageOperatorFal
         event: 'triage.operator_fallback',
         issueNumber,
         issueTitle,
+        issueUrl,
         projectId,
         projectName,
         reason,
@@ -261,8 +263,9 @@ export async function deliverToUser(
   const telegramId = userChannels.telegram?.platformId;
   if (enabledTypes.has('telegram') && telegramId) {
     const isGate = payload.event === 'workflow.gate';
+    const isTriage = payload.event === 'triage.operator_fallback';
     deliveries.push(
-      sendTelegram(telegramId, message, isGate, payload.runId, payload.stepId).then(msgId => {
+      sendTelegram(telegramId, message, isGate, payload.runId, payload.stepId, isTriage, payload.projectId, payload.issueNumber, payload.issueUrl).then(msgId => {
         if (msgId !== null) telegramResult = { chatId: telegramId, messageId: msgId };
       })
     );
@@ -385,11 +388,19 @@ async function sendTelegram(
   isGate: boolean,
   runId?: string,
   stepId?: string,
+  isTriage?: boolean,
+  projectId?: string,
+  issueNumber?: number,
+  issueUrl?: string,
 ): Promise<number | null> {
   try {
     if (isGate && runId && stepId) {
       // Send gate notification with approve/reject buttons — returns message ID
       return await sendGateNotification(chatId, message, runId, stepId);
+    } else if (isTriage && projectId && issueNumber != null) {
+      // Send triage notification with inline action buttons
+      await sendTriageNotification(chatId, message, projectId, issueNumber, issueUrl ?? '');
+      return null;
     } else {
       // Send plain notification (completion/failure)
       await sendPlainNotification(chatId, message);


### PR DESCRIPTION
Closes #107

Triage notifications now include inline buttons:
- 🔄 Run Workflow — dispatches first enabled workflow for the project
- ✅ Mark Triaged — marks issue as triaged
- 🔗 View Issue — links to GitHub

Auth reuses existing Telegram ID → Armada user lookup. 163 tests pass, zero TS errors.