### PR TITLE
feat: GitHub issue lifecycle — dismiss, auto-close on completion, labels (#131)

### DIFF
--- a/packages/control/src/routes/triage.ts
+++ b/packages/control/src/routes/triage.ts
@@ -3,6 +3,20 @@ import { requireScope } from '../middleware/scopes.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  name: 'armada_triage_dismiss',
+  description: 'Dismiss a GitHub issue — mark it as triaged and optionally close it on GitHub with a wontfix label.',
+  method: 'POST',
+  path: '/api/triage/dismiss',
+  parameters: [
+    { name: 'projectId', type: 'string', description: 'Project ID', required: true },
+    { name: 'issueNumber', type: 'number', description: 'GitHub issue number', required: true },
+    { name: 'reason', type: 'string', description: 'Reason for dismissal', required: true },
+    { name: 'closeOnGithub', type: 'boolean', description: 'Also close the issue on GitHub and add wontfix label' },
+  ],
+  scope: 'tasks:write',
+});
+
+registerToolDef({
   name: 'armada_triage_scan',
   description: 'Scan all projects for untriaged GitHub issues and dispatch triage to PM agents.',
   method: 'POST', path: '/api/triage/scan',
@@ -46,7 +60,7 @@ registerToolDef({
   scope: 'workflows:write',
 });
 
-import { triageIssue, handleTriageResult, triageNewIssues, markIssueTriaged, triageDispatch } from '../services/triage.js';
+import { triageIssue, handleTriageResult, triageNewIssues, markIssueTriaged, triageDispatch, triageDismiss } from '../services/triage.js';
 import { getCachedIssues } from '../services/github-sync.js';
 
 const router = Router();
@@ -149,6 +163,30 @@ router.post('/dispatch', requireScope('workflows:write'), async (req, res) => {
   }
 
   res.json({ ok: true, runId: result.runId, workflowName: result.workflowName });
+});
+
+/** POST /api/triage/dismiss — Dismiss an issue (mark triaged, optionally close on GitHub) */
+router.post('/dismiss', requireScope('tasks:write'), async (req, res) => {
+  const { projectId, issueNumber, reason, closeOnGithub } = req.body;
+  if (!projectId || !issueNumber || !reason) {
+    res.status(400).json({ error: 'projectId, issueNumber, and reason are required' });
+    return;
+  }
+
+  const result = await triageDismiss({
+    projectId,
+    issueNumber: Number(issueNumber),
+    reason,
+    closeOnGithub: Boolean(closeOnGithub),
+  });
+
+  if (result.error) {
+    // Still dismissed locally — return 200 with warning
+    res.json({ dismissed: result.dismissed, warning: result.error });
+    return;
+  }
+
+  res.json({ dismissed: result.dismissed });
 });
 
 export default router;

--- a/packages/control/src/services/github-actions.ts
+++ b/packages/control/src/services/github-actions.ts
@@ -1,0 +1,142 @@
+/**
+ * GitHub Actions — higher-level helpers for performing issue lifecycle operations
+ * on behalf of a project's configured GitHub integration.
+ *
+ * Uses the existing adapter + registry pattern (same as proxy.ts / integrations/).
+ * Never touches GitHub's REST API directly — all calls go through the adapter.
+ *
+ * Used by:
+ * - triage dismiss  (close issue + add wontfix label)
+ * - workflow completion auto-close (comment + close + label)
+ */
+
+import { getProvider } from './integrations/registry.js';
+import { integrationsRepo } from './integrations/integrations-repo.js';
+import { projectIntegrationsRepo } from './integrations/project-integrations-repo.js';
+import type { IntegrationProvider, AuthConfig } from './integrations/types.js';
+
+// ── URL parser ─────────────────────────────────────────────────────────────────
+
+export function parseGithubIssueUrl(url: string): { owner: string; repo: string; number: number } | null {
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+
+/** Convert owner/repo + number to the canonical issue key used by the adapter: owner/repo#number */
+function toIssueKey(owner: string, repo: string, number: number): string {
+  return `${owner}/${repo}#${number}`;
+}
+
+// ── Integration resolution ─────────────────────────────────────────────────────
+
+interface ResolvedIntegration {
+  provider: IntegrationProvider;
+  authConfig: AuthConfig;
+}
+
+/**
+ * Resolve the issues integration + adapter for a project.
+ * Mirrors the `resolveIssueIntegration` helper in routes/proxy.ts.
+ */
+function resolveProjectIssueIntegration(projectId: string): ResolvedIntegration | null {
+  const pis = projectIntegrationsRepo.getByProject(projectId);
+  const issuePI = pis.find(pi => pi.capability === 'issues' && pi.enabled);
+  if (!issuePI) return null;
+
+  const integration = integrationsRepo.getById(issuePI.integrationId);
+  if (!integration || integration.status !== 'active') return null;
+
+  const provider = getProvider(integration.provider);
+  if (!provider) return null;
+
+  return { provider, authConfig: integration.authConfig };
+}
+
+// ── Public API helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Post a comment on a GitHub issue via the project's integration.
+ */
+export async function addComment(
+  projectId: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<void> {
+  const resolved = resolveProjectIssueIntegration(projectId);
+  if (!resolved) {
+    console.warn(`[github-actions] No active issues integration for project ${projectId} — cannot add comment`);
+    return;
+  }
+
+  if (!resolved.provider.addComment) {
+    console.warn(`[github-actions] Provider does not support addComment`);
+    return;
+  }
+
+  const issueKey = toIssueKey(owner, repo, issueNumber);
+  await resolved.provider.addComment(resolved.authConfig, issueKey, body);
+}
+
+/**
+ * Close a GitHub issue via the project's integration, optionally posting a comment first.
+ */
+export async function closeIssue(
+  projectId: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  comment?: string,
+): Promise<void> {
+  const resolved = resolveProjectIssueIntegration(projectId);
+  if (!resolved) {
+    console.warn(`[github-actions] No active issues integration for project ${projectId} — cannot close issue`);
+    return;
+  }
+
+  const issueKey = toIssueKey(owner, repo, issueNumber);
+
+  // Post comment first if provided
+  if (comment && resolved.provider.addComment) {
+    try {
+      await resolved.provider.addComment(resolved.authConfig, issueKey, comment);
+    } catch (err: any) {
+      console.warn(`[github-actions] Failed to post comment on ${issueKey}: ${err.message}`);
+      // Don't throw — still attempt to close
+    }
+  }
+
+  if (!resolved.provider.updateIssueStatus) {
+    console.warn(`[github-actions] Provider does not support updateIssueStatus — cannot close issue`);
+    return;
+  }
+
+  await resolved.provider.updateIssueStatus(resolved.authConfig, issueKey, 'closed');
+}
+
+/**
+ * Add a label to a GitHub issue via the project's integration.
+ */
+export async function addLabel(
+  projectId: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  const resolved = resolveProjectIssueIntegration(projectId);
+  if (!resolved) {
+    console.warn(`[github-actions] No active issues integration for project ${projectId} — cannot add label`);
+    return;
+  }
+
+  if (!resolved.provider.addIssueLabel) {
+    console.warn(`[github-actions] Provider does not support addIssueLabel`);
+    return;
+  }
+
+  const issueKey = toIssueKey(owner, repo, issueNumber);
+  await resolved.provider.addIssueLabel(resolved.authConfig, issueKey, label);
+}

--- a/packages/control/src/services/integrations/github-adapter.ts
+++ b/packages/control/src/services/integrations/github-adapter.ts
@@ -252,6 +252,53 @@ export class GitHubAdapter implements IntegrationProvider {
     });
   }
 
+  async updateIssueStatus(auth: AuthConfig, issueKey: string, status: string): Promise<void> {
+    const match = issueKey.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+    if (!match) {
+      throw new Error(`Invalid GitHub issue key format: ${issueKey}`);
+    }
+
+    const [, owner, repo, number] = match;
+
+    // GitHub only supports 'open' and 'closed'
+    const state = status === 'closed' ? 'closed' : 'open';
+
+    await this.fetchGitHub(auth, `/repos/${owner}/${repo}/issues/${number}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ state }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  async addIssueLabel(auth: AuthConfig, issueKey: string, label: string): Promise<void> {
+    const match = issueKey.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+    if (!match) {
+      throw new Error(`Invalid GitHub issue key format: ${issueKey}`);
+    }
+
+    const [, owner, repo, number] = match;
+
+    // Ensure label exists — create it if not (422 = already exists, safe to ignore)
+    try {
+      await this.fetchGitHub(auth, `/repos/${owner}/${repo}/labels`, {
+        method: 'POST',
+        body: JSON.stringify({ name: label, color: '0075ca' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (err: any) {
+      // "already_exists" from GitHub returns 422 — our fetchGitHub throws on !resp.ok
+      if (!err.message?.includes('422')) {
+        console.warn(`[github-adapter] Could not ensure label "${label}" exists: ${err.message}`);
+      }
+    }
+
+    await this.fetchGitHub(auth, `/repos/${owner}/${repo}/issues/${number}/labels`, {
+      method: 'POST',
+      body: JSON.stringify({ labels: [label] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   async listRepos(auth: AuthConfig): Promise<ExternalRepo[]> {
     try {
       const data = await this.fetchGitHub<Array<Record<string, any>>>(

--- a/packages/control/src/services/integrations/types.ts
+++ b/packages/control/src/services/integrations/types.ts
@@ -116,6 +116,7 @@ export interface IntegrationProvider {
   getIssue?(auth: AuthConfig, issueKey: string): Promise<ExternalIssue>;
   updateIssueStatus?(auth: AuthConfig, issueKey: string, status: string): Promise<void>;
   addComment?(auth: AuthConfig, issueKey: string, comment: string): Promise<void>;
+  addIssueLabel?(auth: AuthConfig, issueKey: string, label: string): Promise<void>;
   
   // VCS
   listRepos?(auth: AuthConfig): Promise<ExternalRepo[]>;

--- a/packages/control/src/services/telegram-bot.ts
+++ b/packages/control/src/services/telegram-bot.ts
@@ -275,6 +275,39 @@ export async function initTelegramBot(): Promise<void> {
             );
             await ctx.answerCallbackQuery({ text: '✅ Marked as triaged' });
 
+          } else if ((isShort ? action === 'x' : action === 'dismiss') && parts.length >= 4) {
+            // Short: t:x:<pid8>:<issueNumber>
+            const pidFragment = parts[2];
+            const issueNumber = parseInt(parts[3], 10);
+
+            // Resolve short ID to full project ID
+            const { projectsRepo: pr } = await import('../repositories/index.js');
+            const proj = pr.getAll().find(p => p.id.startsWith(pidFragment)) ?? pr.getAll().find(p => p.id === pidFragment);
+            const projectId = proj?.id ?? pidFragment;
+
+            await ctx.answerCallbackQuery({ text: '❌ Dismissing...' });
+
+            const { triageDismiss } = await import('./triage.js');
+            const result = await triageDismiss({
+              projectId,
+              issueNumber,
+              reason: `Dismissed via Telegram by ${user.displayName}`,
+              closeOnGithub: true,
+            });
+
+            const originalText = ctx.callbackQuery.message?.text ?? '';
+            if (result.error) {
+              await ctx.editMessageText(
+                `${originalText}\n\n❌ Dismissed by ${escapeHtml(user.displayName)} (GitHub close failed: ${escapeHtml(result.error)})`,
+                { parse_mode: 'HTML', reply_markup: undefined },
+              );
+            } else {
+              await ctx.editMessageText(
+                `${originalText}\n\n❌ Dismissed by ${escapeHtml(user.displayName)}`,
+                { parse_mode: 'HTML', reply_markup: undefined },
+              );
+            }
+
           } else {
             await ctx.answerCallbackQuery({ text: 'Unknown triage action' });
           }
@@ -535,7 +568,8 @@ export async function sendTriageNotification(
   for (const wf of workflows) {
     keyboard.text(`🔄 ${wf.name}`, `t:d:${pid}:${issueNumber}:${wf.id.slice(0, 8)}`).row();
   }
-  keyboard.text('✅ Mark Triaged', `t:m:${pid}:${issueNumber}`);
+  keyboard.text('✅ Mark Triaged', `t:m:${pid}:${issueNumber}`).row();
+  keyboard.text('❌ Dismiss', `t:x:${pid}:${issueNumber}`);
 
   if (issueUrl) {
     keyboard.row().url('🔗 View Issue', issueUrl);

--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -535,6 +535,55 @@ export function markIssueTriaged(projectId: string, issueNumber: number) {
   markIssueTriage(projectId, issueNumber);
 }
 
+// ── Dismiss an issue ────────────────────────────────────────────────────────
+
+/**
+ * Dismiss an issue — mark it as triaged and optionally close it on GitHub with
+ * a "wontfix" label and a reason comment.
+ */
+export async function triageDismiss(input: {
+  projectId: string;
+  issueNumber: number;
+  reason: string;
+  closeOnGithub?: boolean;
+}): Promise<{ dismissed: boolean; error?: string }> {
+  const { projectId, issueNumber, reason, closeOnGithub = false } = input;
+
+  // Mark locally so it won't be re-triaged
+  markIssueTriaged(projectId, issueNumber);
+
+  logActivity({
+    eventType: 'triage.dismissed',
+    agentName: 'triage-service',
+    detail: `Dismissed issue #${issueNumber}: ${reason}`,
+  });
+
+  if (closeOnGithub) {
+    try {
+      const { closeIssue, addLabel, parseGithubIssueUrl } = await import('./github-actions.js');
+
+      // Resolve owner/repo from the cached issue's HTML URL
+      const issues = getCachedIssues(projectId);
+      const issue = issues.find(i => i.number === issueNumber);
+      const issueUrl = issue?.htmlUrl || (issue as any)?.url || '';
+      const parsed = issueUrl ? parseGithubIssueUrl(issueUrl) : null;
+
+      if (!parsed) {
+        console.warn(`[triage] Cannot close issue #${issueNumber} on GitHub — no issue URL found in cache`);
+        return { dismissed: true };
+      }
+
+      await closeIssue(projectId, parsed.owner, parsed.repo, issueNumber, reason);
+      await addLabel(projectId, parsed.owner, parsed.repo, issueNumber, 'wontfix');
+    } catch (err: any) {
+      console.error(`[triage] Failed to close issue #${issueNumber} on GitHub:`, err.message);
+      return { dismissed: true, error: err.message };
+    }
+  }
+
+  return { dismissed: true };
+}
+
 // ── Auto-triage wiring ────────────────────────────────────────────────────────
 // Subscribe to github.new_issues events emitted by github-sync.ts so that
 // newly discovered issues are automatically triaged without manual intervention.

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -356,7 +356,13 @@ async function advanceRun(
       UPDATE workflow_runs SET status = ${finalStatus}, completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ${run.id}
     `);
 
-    
+    // ── Auto-close GitHub issue on workflow completion ──────────────────
+    if (finalStatus === 'completed' && run.triggerRef) {
+      // Fire-and-forget — failure must not affect run status
+      closeGithubIssueForRun(run, workflow, updatedStepRuns).catch((err: Error) => {
+        console.error('[workflow-engine] GitHub auto-close failed (non-fatal):', err.message);
+      });
+    }
 
     if (_notifyFn) {
       _notifyFn({
@@ -1039,6 +1045,44 @@ function findDownstream(stepId: string, steps: WorkflowStep[]): Set<string> {
   }
 
   return downstream;
+}
+
+// ── Auto-close GitHub issue when a workflow run completes ───────────
+
+/**
+ * If the workflow run was triggered by a GitHub issue URL, post a resolution
+ * comment, close the issue, and add the "resolved-by-armada" label.
+ *
+ * Failures are non-fatal — the caller should wrap in try/catch.
+ */
+async function closeGithubIssueForRun(
+  run: WorkflowRun,
+  workflow: Workflow,
+  stepRuns: WorkflowStepRun[],
+): Promise<void> {
+  if (!run.triggerRef) return;
+
+  const { parseGithubIssueUrl, closeIssue, addLabel, addComment } = await import('./github-actions.js');
+
+  const parsed = parseGithubIssueUrl(run.triggerRef);
+  if (!parsed) return; // Not a GitHub issue URL
+
+  const { owner, repo, number: issueNumber } = parsed;
+
+  // Get the last completed step's output as summary
+  const completedSteps = stepRuns.filter(sr => sr.status === 'completed' && sr.output);
+  const finalOutput = completedSteps.length > 0
+    ? completedSteps[completedSteps.length - 1].output ?? ''
+    : '';
+
+  const comment =
+    `✅ Resolved by Armada workflow "${workflow.name}"\n\n## Summary\n${finalOutput}`.trimEnd();
+
+  await addComment(run.projectId, owner, repo, issueNumber, comment);
+  await closeIssue(run.projectId, owner, repo, issueNumber);
+  await addLabel(run.projectId, owner, repo, issueNumber, 'resolved-by-armada');
+
+  console.log(`[workflow-engine] Auto-closed GitHub issue ${owner}/${repo}#${issueNumber} after workflow "${workflow.name}" completed`);
 }
 
 // ── Cancel a run ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #131

Uses existing integration adapter pattern (not raw API):
- `triageDismiss()` — marks triaged + closes issue on GitHub + adds wontfix label
- Auto-close on workflow completion — posts summary comment + closes + adds resolved-by-armada
- Telegram dismiss button (❌)
- `POST /api/triage/dismiss` endpoint + `armada_triage_dismiss` tool
- Added `updateIssueStatus` and `addIssueLabel` to GitHub adapter

163 tests pass, zero TS errors.