### PR TITLE
feat: workflow cancel aborts running agent tasks via /armada/abort (#133)

### DIFF
--- a/packages/control/src/routes/workflows.ts
+++ b/packages/control/src/routes/workflows.ts
@@ -479,8 +479,8 @@ router.post('/runs/:runId/rework', requireScope('workflows:write'), async (req, 
 });
 
 /** POST /api/workflow-runs/:runId/cancel */
-router.post('/runs/:runId/cancel', requireScope('workflows:write'), (req, res) => {
-  cancelRun(req.params.runId);
+router.post('/runs/:runId/cancel', requireScope('workflows:write'), async (req, res) => {
+  await cancelRun(req.params.runId);
   logAudit(req, 'workflow.run_cancel', 'workflow_run', req.params.runId);
   res.json({ cancelled: true });
 });

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -18,7 +18,8 @@ import { eq, and, desc, sql, inArray } from 'drizzle-orm';
 import { dispatchWebhook } from './webhook-dispatcher.js';
 import { broadcast } from '../utils/event-bus.js';
 import { getArtifactContextBlock } from '../routes/workflow-artifacts.js';
-import { projectsRepo } from '../repositories/index.js';
+import { projectsRepo, agentsRepo, instancesRepo } from '../repositories/index.js';
+import { getNodeClient } from '../infrastructure/node-client.js';
 
 // Types — mirror shared package types locally to avoid build ordering issues
 interface WorkflowStep {
@@ -1087,12 +1088,41 @@ async function closeGithubIssueForRun(
 
 // ── Cancel a run ────────────────────────────────────────────────────
 
-export function cancelRun(runId: string): void {
+export async function cancelRun(runId: string): Promise<void> {
   const db = getDrizzle();
   const now = sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`;
+
+  // Query running step runs BEFORE updating status (we need agentName + taskId)
+  const runningSteps = db.select().from(workflowStepRuns)
+    .where(and(eq(workflowStepRuns.runId, runId), eq(workflowStepRuns.status, 'running')))
+    .all();
+
   db.run(sql`UPDATE workflow_runs SET status = 'cancelled', completed_at = ${now} WHERE id = ${runId}`);
   db.run(sql`UPDATE workflow_step_runs SET status = 'cancelled', completed_at = ${now} WHERE run_id = ${runId} AND status = 'running'`);
   db.run(sql`UPDATE workflow_step_runs SET status = 'skipped' WHERE run_id = ${runId} AND status IN ('pending', 'waiting_gate', 'waiting_for_rework')`);
+
+  // Fire-and-forget abort requests to running agents
+  for (const stepRun of runningSteps) {
+    if (!stepRun.agentName || !stepRun.taskId) continue;
+
+    try {
+      const agentRecord = agentsRepo.getAll().find(a => a.name === stepRun.agentName);
+      if (!agentRecord?.instanceId) continue;
+
+      const instance = instancesRepo.getById(agentRecord.instanceId);
+      if (!instance?.nodeId) continue;
+
+      const containerName = `armada-instance-${instance.name}`;
+      const node = getNodeClient(instance.nodeId);
+
+      node.relayRequest(containerName, 'POST', '/armada/abort', { taskId: stepRun.taskId })
+        .catch((err: any) => {
+          console.warn(`[workflow-engine] Failed to abort task ${stepRun.taskId} on ${stepRun.agentName}: ${err.message}`);
+        });
+    } catch (err: any) {
+      console.warn(`[workflow-engine] Error sending abort for step ${stepRun.stepId}: ${err.message}`);
+    }
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/plugins/agent/src/index.ts
+++ b/plugins/agent/src/index.ts
@@ -1036,6 +1036,45 @@ export default function register(api: any) {
     },
   });
 
+  // ── HTTP: Abort — cancel a running inbound task ─────────────────────
+
+  api.registerHttpRoute({
+    auth: 'plugin',
+    path: '/armada/abort',
+    handler: async (req: IncomingMessage, res: ServerResponse) => {
+      const body = await readBody(req);
+      const { taskId } = body;
+
+      if (!taskId) {
+        return sendJson(res, 400, { error: 'taskId required' });
+      }
+
+      // Find the inbound context for this task
+      let inbound: InboundContext | undefined;
+      for (const [, ctx] of inboundContexts) {
+        if (ctx.taskId === taskId) { inbound = ctx; break; }
+      }
+
+      if (!inbound) {
+        _logger.warn(`[armada-agent] Abort requested for unknown task ${taskId}`);
+        return sendJson(res, 404, { error: `No active task found: ${taskId}` });
+      }
+
+      if (inbound.finalized) {
+        return sendJson(res, 200, { aborted: false, taskId, reason: 'already finalized' });
+      }
+
+      _logger.info(`[armada-agent] Aborting task ${taskId} via /armada/abort`);
+      sendJson(res, 200, { aborted: true, taskId });
+
+      // Finalize with cancelled status (fire-and-forget)
+      finalizeInbound(inbound, 'Task cancelled by workflow engine', 'cancelled', _logger);
+      _activeTasks--;
+      reportTask('update', { id: taskId, status: 'cancelled' });
+      saveAgentTasks();
+    },
+  });
+
   // ── HTTP: Notify — receive notifications from armada control ────────
 
   api.registerHttpRoute({


### PR DESCRIPTION
Closes #133

- cancelRun() now queries running steps, resolves agent→instance→node, sends abort via relay
- New /armada/abort plugin endpoint: looks up inbound context, calls finalizeInbound with 'cancelled'
- Route handler made async

163 tests pass, zero TS errors.