### PR TITLE
fix: project metrics, activity, and agents tabs populated from real data (#134)

### DIFF
--- a/packages/control/src/repositories/project-repo.ts
+++ b/packages/control/src/repositories/project-repo.ts
@@ -133,17 +133,32 @@ export const projectsRepo = {
     if (!project) return [];
     const allTemplates = db.select().from(templates).all();
     const allAgents = db.select().from(agents).all();
-    const memberNames: string[] = [];
+    const memberNames = new Set<string>();
+
+    // 1. Agents whose template has this project in projects_json
     for (const agent of allAgents) {
       if (!agent.templateId) continue;
       const tmpl = allTemplates.find(t => t.id === agent.templateId);
       if (!tmpl) continue;
       const projectsList = parseJsonWithSchema('[project-repo] projectsJson', tmpl.projectsJson || '[]', stringArraySchema, []);
-      if (projectsList.includes(project.name)) {
-        memberNames.push(agent.name);
+      if (projectsList.includes(project.name) || projectsList.includes(project.id)) {
+        memberNames.add(agent.name);
       }
     }
-    return memberNames;
+
+    // 2. Agents that have run workflow steps for this project
+    const workflowAgentRows = db.all<{ agent_name: string }>(
+      sql`SELECT DISTINCT wsr.agent_name
+          FROM workflow_step_runs wsr
+          INNER JOIN workflow_runs wr ON wr.id = wsr.run_id
+          WHERE wr.project_id = ${project.id}
+            AND wsr.agent_name IS NOT NULL`,
+    );
+    for (const row of workflowAgentRows) {
+      if (row.agent_name) memberNames.add(row.agent_name);
+    }
+
+    return Array.from(memberNames);
   },
 };
 

--- a/packages/control/src/routes/tasks.ts
+++ b/packages/control/src/routes/tasks.ts
@@ -47,9 +47,12 @@ router.get('/', (req, res) => {
   const limit = Math.min(parseInt(req.query.limit as string, 10) || 50, 200);
   const agent = req.query.agent as string | undefined;
   const status = req.query.status as string | undefined;
+  const projectId = req.query.projectId as string | undefined;
 
   let tasks: MeshTask[];
-  if (agent) {
+  if (projectId) {
+    tasks = tasksRepo.getByProject(projectId, limit);
+  } else if (agent) {
     tasks = tasksRepo.getByAgent(agent, limit);
   } else if (status) {
     tasks = tasksRepo.getByStatus(status, limit);

--- a/packages/control/src/services/project-service.ts
+++ b/packages/control/src/services/project-service.ts
@@ -61,21 +61,42 @@ export function getProjectMetrics(projectId: string): ProjectMetrics | null {
   const db = getDrizzle();
   const pid = project.name;
 
-  // Tasks by status
+  // Tasks by status — union of:
+  //   1. Tasks directly linked to this project (project_id = project name)
+  //   2. Tasks linked via workflow step runs → workflow runs → project
+  // This handles both legacy tasks (no project_id) and new tasks (project_id set).
   const taskRows = db.all<{ status: string; count: number }>(
-    sql`SELECT status, COUNT(*) as count FROM tasks WHERE project_id = ${pid} GROUP BY status`,
+    sql`SELECT status, COUNT(*) as count FROM (
+      SELECT t.status FROM tasks t
+      WHERE t.project_id = ${pid}
+      UNION ALL
+      SELECT t.status FROM tasks t
+      INNER JOIN workflow_step_runs wsr ON wsr.task_id = t.id
+      INNER JOIN workflow_runs wr ON wr.id = wsr.run_id
+      WHERE wr.project_id = ${project.id}
+        AND (t.project_id IS NULL OR t.project_id != ${pid})
+    ) GROUP BY status`,
   );
   const taskCounts: Record<string, number> = {};
   let taskTotal = 0;
   for (const r of taskRows) { taskCounts[r.status] = r.count; taskTotal += r.count; }
 
-  // Task timing
+  // Task timing — same union approach
   const timingRow = db.get<{ avg_ms: number | null; min_ms: number | null; max_ms: number | null }>(
     sql`SELECT
       AVG(CASE WHEN completed_at IS NOT NULL THEN (julianday(completed_at) - julianday(created_at)) * 86400000 END) as avg_ms,
       MIN(CASE WHEN completed_at IS NOT NULL THEN (julianday(completed_at) - julianday(created_at)) * 86400000 END) as min_ms,
       MAX(CASE WHEN completed_at IS NOT NULL THEN (julianday(completed_at) - julianday(created_at)) * 86400000 END) as max_ms
-    FROM tasks WHERE project_id = ${pid}`,
+    FROM (
+      SELECT t.created_at, t.completed_at FROM tasks t
+      WHERE t.project_id = ${pid}
+      UNION ALL
+      SELECT t.created_at, t.completed_at FROM tasks t
+      INNER JOIN workflow_step_runs wsr ON wsr.task_id = t.id
+      INNER JOIN workflow_runs wr ON wr.id = wsr.run_id
+      WHERE wr.project_id = ${project.id}
+        AND (t.project_id IS NULL OR t.project_id != ${pid})
+    )`,
   ) ?? { avg_ms: null, min_ms: null, max_ms: null };
 
   // Workflow runs by status
@@ -109,7 +130,8 @@ export function getProjectMetrics(projectId: string): ProjectMetrics | null {
     }
   }
 
-  // Activity counts
+  // Activity counts — count workflow step runs completed/started for this project
+  // (more accurate than tasks since every workflow step = one unit of work)
   const now = new Date();
   const ago24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
   const ago7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
@@ -117,7 +139,17 @@ export function getProjectMetrics(projectId: string): ProjectMetrics | null {
 
   const activityCount = (since: string) => {
     const row = db.get<{ count: number }>(
-      sql`SELECT COUNT(*) as count FROM tasks WHERE project_id = ${pid} AND created_at >= ${since}`,
+      sql`SELECT COUNT(*) as count FROM (
+        SELECT t.id FROM tasks t
+        WHERE t.project_id = ${pid} AND t.created_at >= ${since}
+        UNION ALL
+        SELECT t.id FROM tasks t
+        INNER JOIN workflow_step_runs wsr ON wsr.task_id = t.id
+        INNER JOIN workflow_runs wr ON wr.id = wsr.run_id
+        WHERE wr.project_id = ${project.id}
+          AND (t.project_id IS NULL OR t.project_id != ${pid})
+          AND t.created_at >= ${since}
+      )`,
     );
     return row?.count ?? 0;
   };
@@ -129,7 +161,18 @@ export function getProjectMetrics(projectId: string): ProjectMetrics | null {
     const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
     const dayLabel = dayStart.toISOString().slice(0, 10);
     const row = db.get<{ count: number }>(
-      sql`SELECT COUNT(*) as count FROM tasks WHERE project_id = ${pid} AND created_at >= ${dayStart.toISOString()} AND created_at < ${dayEnd.toISOString()}`,
+      sql`SELECT COUNT(*) as count FROM (
+        SELECT t.id FROM tasks t
+        WHERE t.project_id = ${pid}
+          AND t.created_at >= ${dayStart.toISOString()} AND t.created_at < ${dayEnd.toISOString()}
+        UNION ALL
+        SELECT t.id FROM tasks t
+        INNER JOIN workflow_step_runs wsr ON wsr.task_id = t.id
+        INNER JOIN workflow_runs wr ON wr.id = wsr.run_id
+        WHERE wr.project_id = ${project.id}
+          AND (t.project_id IS NULL OR t.project_id != ${pid})
+          AND t.created_at >= ${dayStart.toISOString()} AND t.created_at < ${dayEnd.toISOString()}
+      )`,
     );
     dailyActivity.push({ date: dayLabel, count: row?.count ?? 0 });
   }

--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -289,6 +289,7 @@ If none of the workflows fit, respond with:
       taskText: `Triage issue #${issue.number}: ${issue.title}`,
       result: null,
       status: 'running',
+      projectId: projectName,
     });
 
     markIssueTriage(projectId, issue.number);

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -52,6 +52,11 @@ function findAgentByRole(role: string): { name: string; url: string; targetAgent
 export function initWorkflowDispatcher() {
   setWorkflowDispatcher(async (opts) => {
     const agent = findAgentByRole(opts.role);
+    // Resolve project UUID → project name (tasks table stores name as project_id)
+    const projectName = opts.projectId
+      ? (projectsRepo.get(opts.projectId)?.name ?? opts.projectId)
+      : undefined;
+
     if (!agent) {
       const errMsg = `No running agent with role "${opts.role}" available`;
       // Create the task record as failed so checkWorkflowStep can advance the workflow
@@ -63,6 +68,7 @@ export function initWorkflowDispatcher() {
         result: errMsg,
         status: 'failed',
         workflowRunId: opts.runId,
+        projectId: projectName,
       });
       checkWorkflowStep(opts.taskId, 'failed', errMsg);
       return { error: errMsg };
@@ -77,6 +83,7 @@ export function initWorkflowDispatcher() {
       result: null,
       status: 'pending',
       workflowRunId: opts.runId,
+      projectId: projectName,
     });
 
     // Dispatch via node relay (routes through node agent → container)

--- a/packages/ui/src/pages/ProjectDetail.tsx
+++ b/packages/ui/src/pages/ProjectDetail.tsx
@@ -1931,7 +1931,7 @@ export default function ProjectDetail() {
       const [issueData, memberData, taskData, metricsData] = await Promise.all([
         apiFetch<GitHubIssue[]>(`/api/projects/${id}/issues`).catch(() => []),
         apiFetch<{ members: AgentInfo[] }>(`/api/projects/${id}/members`).catch(() => ({ members: [] })),
-        apiFetch<ArmadaTask[]>('/api/tasks?limit=50').catch(() => []),
+        apiFetch<ArmadaTask[]>(`/api/tasks?projectId=${encodeURIComponent(project.name)}&limit=50`).catch(() => []),
         apiFetch<ProjectMetrics>(`/api/projects/${id}/metrics`).catch(() => null),
       ]);
       setMetrics(metricsData);
@@ -1964,11 +1964,7 @@ export default function ProjectDetail() {
         setAgents(membersList as AgentInfo[]);
       }
 
-      // Filter tasks for this project
-      const projectTasks = taskData.filter(
-        (t) => t.projectId === project.name || t.projectId === project.id,
-      );
-      setTasks(projectTasks);
+      setTasks(taskData);
 
       // Load workflows
       try {


### PR DESCRIPTION
Closes #134, closes #135

Three root causes fixed:
1. **Metrics zero** — workflow tasks created without projectId → now set during dispatch
2. **Activity empty** — UI fetched all tasks globally, no project filter → now uses ?projectId=
3. **Agents empty** — only checked templates, not workflow history → now includes agents from step runs

Also handles legacy tasks via UNION query (tasks with project_id + tasks linked through workflow_runs).

163 tests pass, zero TS errors.