### PR TITLE
feat: tool categories — load tool subsets on demand (#128)

### DIFF
--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -83,7 +83,12 @@ async function start() {
       if (agent?.role) {
         const allowedScopes = getScopesForAgentRole(agent.role);
         if (!allowedScopes.includes('*')) {
-          const filtered = allTools.filter(t => !t.scope || allowedScopes.includes(t.scope));
+          let filtered = allTools.filter(t => !t.scope || allowedScopes.includes(t.scope));
+          // Apply category filter after scope filter
+          const categories = (req.query.categories as string)?.split(',').filter(Boolean);
+          if (categories?.length) {
+            filtered = filtered.filter(t => t.category && categories.includes(t.category));
+          }
           return res.json(filtered);
         }
       }
@@ -95,12 +100,25 @@ async function start() {
     // No scopes = return all (backward compat: unauthenticated or operator without scope restriction)
     // Wildcard = return all
     if (callerScopes.length === 0 || callerScopes.includes('*')) {
-      return res.json(allTools);
+      let result = allTools;
+      // Apply category filter if requested
+      const categories = (req.query.categories as string)?.split(',').filter(Boolean);
+      if (categories?.length) {
+        result = result.filter(t => t.category && categories.includes(t.category));
+      }
+      return res.json(result);
     }
     
     // Filter tools to only those the caller has scope for
     // Tools without a scope field are accessible to everyone
-    const filtered = allTools.filter(t => !t.scope || callerScopes.includes(t.scope));
+    let filtered = allTools.filter(t => !t.scope || callerScopes.includes(t.scope));
+
+    // Apply category filter after scope filter
+    const categories = (req.query.categories as string)?.split(',').filter(Boolean);
+    if (categories?.length) {
+      filtered = filtered.filter(t => t.category && categories.includes(t.category));
+    }
+
     res.json(filtered);
   });
 

--- a/packages/control/src/routes/activity.ts
+++ b/packages/control/src/routes/activity.ts
@@ -78,6 +78,7 @@ router.get('/stream', (req, res) => {
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_activity_list',
   description: 'List recent armada activity events with optional filtering by agent or event type',
   method: 'GET',

--- a/packages/control/src/routes/agents.ts
+++ b/packages/control/src/routes/agents.ts
@@ -30,6 +30,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   // ── Tool definitions (auto-discovered by armada-control plugin) ────
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_status',
     description: 'Check the status of all armada instances. Shows which agents are running and available for armada_task.',
     method: 'GET', path: '/api/agents',
@@ -38,6 +39,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_spawn',
     description: 'Spawn a new agent from a template. Contact sync runs automatically after spawn.',
     method: 'POST', path: '/api/agents',
@@ -49,6 +51,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_redeploy',
     description: 'Regenerate an agent\'s config, SOUL.md, and AGENTS.md from its template, then restart. Use after template changes. Pass "all" to redeploy every agent.',
     method: 'POST', path: '/api/agents/:name/redeploy',
@@ -60,6 +63,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_destroy',
     description: 'Destroy a agent — stops and removes its container, deletes the agent record. Contact sync runs automatically after deletion.',
     method: 'DELETE', path: '/api/agents/:name',
@@ -70,6 +74,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_logs',
     description: 'Get recent logs from a agent\'s instance container.',
     method: 'GET', path: '/api/agents/:name/logs',
@@ -82,6 +87,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_heartbeat',
     description: 'Send a heartbeat for an agent to indicate it is alive. Optionally include metadata (taskCount, memoryMb, uptimeMs).',
     method: 'POST', path: '/api/agents/:name/heartbeat',
@@ -95,6 +101,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_nudge',
     description: 'Send a quick health-check nudge to an agent and wait for a response (up to 30s). Returns the agent\'s status reply.',
     method: 'POST', path: '/api/agents/:name/nudge',
@@ -106,6 +113,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_avatar_generate',
     description: 'Generate an AI avatar image for a agent based on its name and role.',
     method: 'POST', path: '/api/agents/:name/avatar/generate',
@@ -116,6 +124,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_avatar_delete',
     description: 'Delete the avatar image for a agent.',
     method: 'DELETE', path: '/api/agents/:name/avatar',
@@ -126,6 +135,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_maintain',
     description: 'Perform graceful maintenance on a agent — drains active tasks, signals graceful restart (SIGUSR1), and waits for the agent to come back healthy. Long-running operation (up to ~2.5 minutes).',
     method: 'POST', path: '/api/agents/:name/maintain',
@@ -138,6 +148,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_agent_capacity',
     description: 'Get capacity info for all agents — task count, response latency, and health status. Useful for checking agent load.',
     method: 'GET', path: '/api/agents/capacity',
@@ -146,6 +157,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_agent_sessions',
     description: 'Get agent session list',
     method: 'GET', path: '/api/agents/:name/session',
@@ -156,6 +168,7 @@ export function createAgentRoutes(nodeManager: NodeManager): Router {
   });
 
   registerToolDef({
+  category: 'instances',
     name: 'armada_agent_session_messages',
     description: 'Get session messages',
     method: 'GET', path: '/api/agents/:name/session/messages',

--- a/packages/control/src/routes/assignments.ts
+++ b/packages/control/src/routes/assignments.ts
@@ -26,6 +26,7 @@ const router = Router({ mergeParams: true });
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_assignments_list',
   description: 'List all responsibility assignments for a project (triager, approver, owner).',
   method: 'GET',
@@ -37,6 +38,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_assignment_set',
   description: 'Set a responsibility assignment for a project. Assignment types: triager, approver, owner. Assignee types: user, agent, role.',
   method: 'PUT',
@@ -51,6 +53,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_assignment_remove',
   description: 'Remove a responsibility assignment from a project.',
   method: 'DELETE',
@@ -63,6 +66,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_assignment_resolve',
   description: 'Resolve the effective assignee for a triager or approver slot, following the full priority chain.',
   method: 'GET',

--- a/packages/control/src/routes/audit.ts
+++ b/packages/control/src/routes/audit.ts
@@ -4,6 +4,7 @@ import { queryAudit } from '../services/audit.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_audit_list',
   description: 'Query the audit log. Returns recent audit entries with optional filters.',
   method: 'GET',

--- a/packages/control/src/routes/badges.ts
+++ b/packages/control/src/routes/badges.ts
@@ -4,6 +4,7 @@ import { Router } from 'express';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_badges',
   description: 'Get badge counts for nav items (pending gates, active operations, error instances).',
   method: 'GET', path: '/api/badges', parameters: [],

--- a/packages/control/src/routes/config.ts
+++ b/packages/control/src/routes/config.ts
@@ -3,6 +3,7 @@ import { configDiffService } from '../services/config-diff.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  category: 'system',
   name: 'armada_config_status',
   description: 'Get the current config version, stale instances, and pending restarts.',
   method: 'GET', path: '/api/config/status', parameters: [],
@@ -10,6 +11,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_config_snapshot',
   description: 'Take a snapshot of the current config state (providers, models, plugins, template models).',
   method: 'GET', path: '/api/config/snapshot', parameters: [],

--- a/packages/control/src/routes/credentials.ts
+++ b/packages/control/src/routes/credentials.ts
@@ -97,6 +97,7 @@ export function createCredentialRoutes(nodeManager: NodeManager): Router {
   // ── Tool definitions ──────────────────────────────────────────────
 
   registerToolDef({
+  category: 'integrations',
     name: 'armada_agent_credentials_sync',
     description: 'Trigger git credential sync for a agent. Pushes VCS tokens from integrations to the agent container.',
     method: 'POST',

--- a/packages/control/src/routes/deploys.ts
+++ b/packages/control/src/routes/deploys.ts
@@ -5,6 +5,7 @@ import { registerToolDef } from '../utils/tool-registry.js';
 const router = Router();
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_deploys',
   description: 'List recent deployment history for agents.',
   method: 'GET', path: '/api/deploys',

--- a/packages/control/src/routes/files.ts
+++ b/packages/control/src/routes/files.ts
@@ -122,6 +122,7 @@ router.get('/list/:agent', async (req, res) => {
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'git',
   name: 'armada_transfer',
   description: 'Transfer a file from one agent\'s workspace to another. The file is copied via the node agent — works across machines.',
   method: 'POST',
@@ -136,6 +137,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'git',
   name: 'armada_share',
   description: 'Share a file from an agent\'s workspace. Returns a ref that can be used to download or deliver the file.',
   method: 'POST',

--- a/packages/control/src/routes/hierarchy.ts
+++ b/packages/control/src/routes/hierarchy.ts
@@ -8,6 +8,7 @@ import { logActivity } from '../services/activity-service.js';
 const router = Router();
 
 registerToolDef({
+  category: 'hierarchy',
   name: 'armada_hierarchy',
   description: 'Get the task routing rules. Shows which roles can assign tasks to which other roles.',
   method: 'GET', path: '/api/hierarchy',
@@ -15,6 +16,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'hierarchy',
   name: 'armada_hierarchy_update',
   description: 'Update the task routing rules. Each role maps to an array of roles it can assign tasks to.',
   method: 'PUT', path: '/api/hierarchy',
@@ -23,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'hierarchy',
   name: 'armada_hierarchy_role_upsert',
   description: 'Create or update role metadata (colour, description, tier, icon).',
   method: 'PUT', path: '/api/hierarchy/roles/:role',
@@ -37,6 +40,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'hierarchy',
   name: 'armada_hierarchy_role_delete',
   description: 'Delete role metadata.',
   method: 'DELETE', path: '/api/hierarchy/roles/:role',

--- a/packages/control/src/routes/install-script.ts
+++ b/packages/control/src/routes/install-script.ts
@@ -168,6 +168,7 @@ router.get('/:token', (req, res) => {
 // ── Tool definitions ──────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_install_control',
   description: 'Get the control plane install script — a shell script that pulls and runs the Armada control plane via Docker',
   method: 'GET',
@@ -176,6 +177,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_install_compose',
   description: 'Get a docker-compose.yml template for the Armada control plane (includes optional Cloudflare Tunnel)',
   method: 'GET',

--- a/packages/control/src/routes/instances.ts
+++ b/packages/control/src/routes/instances.ts
@@ -19,6 +19,7 @@ import { setupSSE } from '../utils/sse.js';
 // ── Tool definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_list',
   description: 'List all armada instances. Shows instance name, node, status, and agent count.',
   method: 'GET', path: '/api/instances',
@@ -27,6 +28,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_get',
   description: 'Get details of a specific armada instance.',
   method: 'GET', path: '/api/instances/:id',
@@ -37,6 +39,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_create',
   description: 'Create a new armada instance.',
   method: 'POST', path: '/api/instances',
@@ -54,6 +57,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_update',
   description: 'Update an existing armada instance.',
   method: 'PUT', path: '/api/instances/:id',
@@ -71,6 +75,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_destroy',
   description: 'Destroy a armada instance. Fails if agents are still assigned unless force=true.',
   method: 'DELETE', path: '/api/instances/:id',
@@ -81,6 +86,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_health',
   description: 'Check health of a instance by pinging its gateway URL.',
   method: 'GET', path: '/api/instances/:id/health',
@@ -91,6 +97,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_logs',
   description: 'Tail logs from an agent instance. Returns recent log lines.',
   method: 'GET',
@@ -105,6 +112,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_logs_stream',
   description: 'Stream live logs from an agent instance via SSE.',
   method: 'GET',
@@ -119,6 +127,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'instances',
   name: 'armada_instance_events',
   description: 'Stream real-time events from an agent instance via SSE. Events include session activity, tool calls, agent status changes, and heartbeats.',
   method: 'GET',

--- a/packages/control/src/routes/integrations.ts
+++ b/packages/control/src/routes/integrations.ts
@@ -30,6 +30,7 @@ function triggerCredentialSyncForAllAgents(nodeManager: NodeManager): void {
 // ── Tool Definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integrations_list',
   description: 'List all integrations (masked auth)',
   method: 'GET',
@@ -39,6 +40,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_create',
   description: 'Create a new integration (validate provider exists)',
   method: 'POST',
@@ -54,6 +56,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_get',
   description: 'Get a single integration (masked auth)',
   method: 'GET',
@@ -65,6 +68,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_update',
   description: 'Update an integration',
   method: 'PUT',
@@ -81,6 +85,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_delete',
   description: 'Delete an integration (cascade removes project integrations)',
   method: 'DELETE',
@@ -92,6 +97,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_test',
   description: 'Test connection via provider adapter',
   method: 'POST',
@@ -103,6 +109,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_projects',
   description: 'List available external projects',
   method: 'GET',
@@ -114,6 +121,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_integration_repos',
   description: 'List available repos',
   method: 'GET',
@@ -125,6 +133,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_project_integrations_list',
   description: 'List project\'s integration configs',
   method: 'GET',
@@ -136,6 +145,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_project_integration_attach',
   description: 'Attach integration to project',
   method: 'POST',
@@ -150,6 +160,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_project_integration_update',
   description: 'Update project integration config',
   method: 'PUT',
@@ -164,6 +175,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_project_integration_detach',
   description: 'Detach integration from project',
   method: 'DELETE',
@@ -176,6 +188,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_project_integration_sync',
   description: 'Trigger manual sync',
   method: 'POST',

--- a/packages/control/src/routes/models.ts
+++ b/packages/control/src/routes/models.ts
@@ -16,6 +16,7 @@ function parsePeriod(raw: unknown): UsagePeriod {
 const router = Router();
 
 registerToolDef({
+  category: 'system',
   name: 'armada_models_list',
   description: 'List all models in the armada model registry.',
   method: 'GET', path: '/api/models',
@@ -24,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_model_get',
   description: 'Get a single model from the registry by ID.',
   method: 'GET', path: '/api/models/:id',
@@ -34,6 +36,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_model_create',
   description: 'Add a new model to the registry.',
   method: 'POST', path: '/api/models',
@@ -51,6 +54,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_model_update',
   description: 'Update a model in the registry.',
   method: 'PUT', path: '/api/models/:id',
@@ -69,6 +73,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_model_delete',
   description: 'Delete a model from the registry.',
   method: 'DELETE', path: '/api/models/:id',

--- a/packages/control/src/routes/nodes.ts
+++ b/packages/control/src/routes/nodes.ts
@@ -12,6 +12,7 @@ import { nodeRemovalService } from '../services/node-removal.js';
 
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_nodes',
   description: 'List all armada nodes (Docker hosts). Shows node name, URL, status, and agent count.',
   method: 'GET', path: '/api/nodes',
@@ -20,6 +21,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_get',
   description: 'Get details of a specific armada node.',
   method: 'GET', path: '/api/nodes/:id',
@@ -30,6 +32,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_create',
   description: 'Register a new armada node (Docker host). Nodes connect via WebSocket using an install token.',
   method: 'POST', path: '/api/nodes',
@@ -40,6 +43,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_update',
   description: 'Update an existing armada node.',
   method: 'PUT', path: '/api/nodes/:id',
@@ -51,6 +55,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_delete',
   description: 'Remove a armada node. Fails if agents are still running on it.',
   method: 'DELETE', path: '/api/nodes/:id',
@@ -61,6 +66,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_test',
   description: 'Test connectivity to a armada node.',
   method: 'POST', path: '/api/nodes/:id/test',
@@ -71,6 +77,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_stats',
   description: 'Get resource stats (CPU, memory, disk) from a armada node.',
   method: 'GET', path: '/api/nodes/:id/stats',
@@ -81,6 +88,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_node_capacity',
   description: 'Get capacity overview for a armada node — total resources, used, available, and per-agent breakdown.',
   method: 'GET', path: '/api/nodes/:id/capacity',

--- a/packages/control/src/routes/notification-channels.ts
+++ b/packages/control/src/routes/notification-channels.ts
@@ -8,6 +8,7 @@ import { registerToolDef } from '../utils/tool-registry.js';
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'notifications',
   name: 'armada_notification_channels_list',
   description: 'List all configured notification channels.',
   method: 'GET',
@@ -16,6 +17,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'notifications',
   name: 'armada_notification_channels_create',
   description: 'Create a new notification channel (telegram, slack, discord, email).',
   method: 'POST',
@@ -30,6 +32,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'notifications',
   name: 'armada_notification_channels_update',
   description: 'Update a notification channel.',
   method: 'PUT',
@@ -44,6 +47,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'notifications',
   name: 'armada_notification_channels_delete',
   description: 'Delete a notification channel.',
   method: 'DELETE',
@@ -55,6 +59,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'notifications',
   name: 'armada_notification_channels_test',
   description: 'Send a test message to a notification channel.',
   method: 'POST',

--- a/packages/control/src/routes/operations.ts
+++ b/packages/control/src/routes/operations.ts
@@ -90,6 +90,7 @@ router.get('/:id/stream', (req, res) => {
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_operations_list',
   description: 'List armada operations with optional status filter',
   method: 'GET',
@@ -101,6 +102,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_operation_get',
   description: 'Get details of a specific armada operation',
   method: 'GET',

--- a/packages/control/src/routes/plugin-library.ts
+++ b/packages/control/src/routes/plugin-library.ts
@@ -7,6 +7,7 @@ import { mutationService } from '../services/mutation-service.js';
 // ── Tool definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_list',
   description: 'List all plugins in the plugin library.',
   method: 'GET', path: '/api/plugins/library',
@@ -14,6 +15,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_get',
   description: 'Get a single plugin from the library by ID or name.',
   method: 'GET', path: '/api/plugins/library/:id',
@@ -23,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_add',
   description: 'Add a plugin to the plugin library.',
   method: 'POST', path: '/api/plugins/library',
@@ -37,6 +40,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_update',
   description: 'Update a plugin in the plugin library.',
   method: 'PUT', path: '/api/plugins/library/:id',
@@ -52,6 +56,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_delete',
   description: 'Remove a plugin from the plugin library.',
   method: 'DELETE', path: '/api/plugins/library/:id',
@@ -62,6 +67,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_usage',
   description: 'Get which templates use a library plugin.',
   method: 'GET', path: '/api/plugins/library/:id/usage',
@@ -71,6 +77,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_pull',
   description: 'Pull the latest version of a library plugin.',
   method: 'POST', path: '/api/plugins/library/:id/update',
@@ -81,6 +88,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_library_rollout',
   description: 'Update a plugin and rolling-restart all affected agents. Rolls back on failure.',
   method: 'POST', path: '/api/plugins/library/batch-rollout',

--- a/packages/control/src/routes/plugins.ts
+++ b/packages/control/src/routes/plugins.ts
@@ -10,6 +10,7 @@ import { logActivity } from '../services/activity-service.js';
 const router = Router();
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugins',
   description: 'List all plugins available in the armada shared plugins directory.',
   method: 'GET', path: '/api/plugins',
@@ -17,6 +18,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugin_update',
   description: 'Update a specific plugin in the armada shared plugins directory.',
   method: 'POST', path: '/api/plugins/:id/update',
@@ -27,6 +29,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_plugins_update_all',
   description: 'Update all plugins in the armada shared plugins directory.',
   method: 'POST', path: '/api/plugins/update-all',

--- a/packages/control/src/routes/projects.ts
+++ b/packages/control/src/routes/projects.ts
@@ -32,6 +32,7 @@ const router = Router();
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_projects_list',
   description: 'List all armada projects. Projects provide shared context for agent workstreams.',
   method: 'GET',
@@ -43,6 +44,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_get',
   description: 'Get a single armada project by ID.',
   method: 'GET',
@@ -54,6 +56,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_create',
   description: 'Create a new armada project.',
   method: 'POST',
@@ -70,6 +73,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_update',
   description: 'Update an existing armada project.',
   method: 'PUT',
@@ -87,6 +91,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_delete',
   description: 'Delete a armada project.',
   method: 'DELETE',
@@ -98,6 +103,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_archive',
   description: 'Archive a armada project.',
   method: 'POST',
@@ -109,6 +115,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_unarchive',
   description: 'Unarchive a armada project.',
   method: 'POST',
@@ -120,6 +127,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_members',
   description: 'List agent members of a armada project.',
   method: 'GET',
@@ -131,6 +139,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_repos',
   description: 'List repositories linked to a armada project.',
   method: 'GET',
@@ -142,6 +151,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_sync',
   description: 'Trigger a manual GitHub issue sync for a project. Imports open issues from linked repositories.',
   method: 'POST',
@@ -153,6 +163,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_issues',
   description: 'Get cached GitHub issues for a project backlog. Returns issues not yet promoted to tasks.',
   method: 'GET',
@@ -164,6 +175,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_board',
   description: 'Get the task board for a project, grouped by column (queued, in-progress, review, done).',
   method: 'GET',
@@ -175,6 +187,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_task_board_column',
   description: 'Move a task to a different board column.',
   method: 'PUT',
@@ -187,6 +200,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'projects',
   name: 'armada_project_metrics',
   description: 'Get project-level metrics and stats: task/workflow counts by status, timing, GitHub issues, and recent activity.',
   method: 'GET',

--- a/packages/control/src/routes/providers.ts
+++ b/packages/control/src/routes/providers.ts
@@ -10,12 +10,14 @@ import { workingCopy } from '../services/working-copy.js';
 import type { ModelProvider, ProviderApiKey } from '@coderage-labs/armada-shared';
 
 registerToolDef({
+  category: 'system',
   name: 'armada_providers_list',
   description: 'List all model providers (Anthropic, OpenAI, OpenRouter, Google).',
   method: 'GET', path: '/api/providers', parameters: [],
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_get',
   description: 'Get a model provider by ID.',
   method: 'GET', path: '/api/providers/:id',
@@ -23,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_update',
   description: 'Update a model provider (base URL, enabled state).',
   method: 'PUT', path: '/api/providers/:id',
@@ -35,6 +38,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_discover_models',
   description: 'Discover available models from a provider (requires API key configured).',
   method: 'GET', path: '/api/providers/:id/models',
@@ -42,6 +46,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_sync_models',
   description: 'Sync discovered models into the model registry from a provider.',
   method: 'POST', path: '/api/providers/:id/sync',
@@ -50,6 +55,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_keys_list',
   description: 'List API keys for a provider (masked).',
   method: 'GET', path: '/api/providers/:id/keys',
@@ -57,6 +63,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_provider_key_add',
   description: 'Add a named API key to a provider.',
   method: 'POST', path: '/api/providers/:id/keys',

--- a/packages/control/src/routes/proxy-prs.ts
+++ b/packages/control/src/routes/proxy-prs.ts
@@ -79,6 +79,7 @@ function validateRepo(repos: string[], repo: string): boolean {
 
 // List available repos
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_repos',
   description: 'List available repositories for a project\'s VCS integration',
   method: 'POST',
@@ -133,6 +134,7 @@ router.post('/repos', async (req, res, next) => {
 
 // List PRs
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_list',
   description: 'List pull requests for a project repository',
   method: 'POST',
@@ -197,6 +199,7 @@ router.post('/list', async (req, res, next) => {
 
 // Get a single PR
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_get',
   description: 'Get full details of a pull request including reviews and diff stats',
   method: 'POST',
@@ -234,6 +237,7 @@ router.post('/get', async (req, res, next) => {
 
 // Get PR reviews
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_reviews',
   description: 'Get reviews and inline comments for a pull request',
   method: 'POST',
@@ -271,6 +275,7 @@ router.post('/reviews', async (req, res, next) => {
 
 // Add a comment to a PR
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_comment',
   description: 'Add a comment to a pull request (general or inline)',
   method: 'POST',
@@ -312,6 +317,7 @@ router.post('/comment', requireScope('integrations:write'), async (req, res, nex
 
 // Create a PR
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_create',
   description: 'Create a pull request',
   method: 'POST',
@@ -369,6 +375,7 @@ router.post('/create', requireScope('integrations:write'), async (req, res, next
 
 // Merge a PR
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_merge',
   description: 'Merge a pull request',
   method: 'POST',
@@ -409,6 +416,7 @@ router.post('/merge', requireScope('integrations:write'), async (req, res, next)
 
 // Update a PR
 registerToolDef({
+  category: 'issues',
   name: 'armada_pr_update',
   description: 'Update a pull request (title, body, state, labels, assignees)',
   method: 'POST',

--- a/packages/control/src/routes/proxy.ts
+++ b/packages/control/src/routes/proxy.ts
@@ -60,6 +60,7 @@ function auditLog(agent: string, project: string, action: string, detail?: strin
 
 // List issues for a project
 registerToolDef({
+  category: 'issues',
   name: 'armada_issue_list',
   description: 'List issues from a project\'s connected issue tracker',
   method: 'POST',
@@ -108,6 +109,7 @@ router.post('/list', async (req, res, next) => {
 
 // Get a single issue
 registerToolDef({
+  category: 'issues',
   name: 'armada_issue_get',
   description: 'Get full details of a specific issue',
   method: 'POST',
@@ -143,6 +145,7 @@ router.post('/get', async (req, res, next) => {
 
 // Add a comment to an issue
 registerToolDef({
+  category: 'issues',
   name: 'armada_issue_comment',
   description: 'Add a comment to an issue',
   method: 'POST',
@@ -179,6 +182,7 @@ router.post('/comment', requireScope('integrations:write'), async (req, res, nex
 
 // Transition/change issue status
 registerToolDef({
+  category: 'issues',
   name: 'armada_issue_transition',
   description: 'Change the status of an issue',
   method: 'POST',
@@ -215,6 +219,7 @@ router.post('/transition', requireScope('integrations:write'), async (req, res, 
 
 // Search issues (provider-specific query)
 registerToolDef({
+  category: 'issues',
   name: 'armada_issue_search',
   description: 'Search issues using provider-specific query (JQL for Jira, query for GitHub)',
   method: 'POST',

--- a/packages/control/src/routes/settings.ts
+++ b/packages/control/src/routes/settings.ts
@@ -6,6 +6,7 @@ import { logActivity } from '../services/activity-service.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  category: 'system',
   name: 'armada_settings_get',
   description: 'Get all armada settings (version, retention, avatar generation, sync interval).',
   method: 'GET', path: '/api/settings', parameters: [],
@@ -13,6 +14,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_settings_update',
   description: 'Update a armada setting by key.',
   method: 'PUT', path: '/api/settings',

--- a/packages/control/src/routes/skill-library.ts
+++ b/packages/control/src/routes/skill-library.ts
@@ -7,6 +7,7 @@ import { logActivity } from '../services/activity-service.js';
 // ── Tool definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_list',
   description: 'List all skills in the armada skill library.',
   method: 'GET', path: '/api/skills/library',
@@ -14,6 +15,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_get',
   description: 'Get a single skill from the library by ID or name.',
   method: 'GET', path: '/api/skills/library/:id',
@@ -23,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_add',
   description: 'Add a skill to the armada skill library.',
   method: 'POST', path: '/api/skills/library',
@@ -37,6 +40,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_update',
   description: 'Update a skill in the armada skill library.',
   method: 'PUT', path: '/api/skills/library/:id',
@@ -52,6 +56,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_delete',
   description: 'Remove a skill from the armada skill library.',
   method: 'DELETE', path: '/api/skills/library/:id',
@@ -62,6 +67,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_usage',
   description: 'Get which templates use a library skill.',
   method: 'GET', path: '/api/skills/library/:id/usage',
@@ -71,6 +77,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_library_pull',
   description: 'Pull the latest version of a library skill.',
   method: 'POST', path: '/api/skills/library/:id/update',

--- a/packages/control/src/routes/skills.ts
+++ b/packages/control/src/routes/skills.ts
@@ -6,6 +6,7 @@ import { registerToolDef } from '../utils/tool-registry.js';
 import type { NodeManager } from '../node-manager.js';
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skills',
   description: 'List all available skills across armada nodes.',
   method: 'GET', path: '/api/skills',
@@ -13,6 +14,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_agent_skills',
   description: 'List skills installed on a specific agent.',
   method: 'GET', path: '/api/agents/:name/skills',
@@ -22,6 +24,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_agent_skill_install',
   description: 'Install a skill on a specific agent.',
   method: 'POST', path: '/api/agents/:name/skills',
@@ -33,6 +36,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_agent_skill_remove',
   description: 'Remove a skill from a specific agent.',
   method: 'DELETE', path: '/api/agents/:name/skills/:skill',
@@ -44,6 +48,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_agent_skills_sync',
   description: 'Sync an agent\'s installed skills with its template. Installs missing, optionally removes extras.',
   method: 'POST', path: '/api/agents/:name/skills/sync',
@@ -54,6 +59,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_install',
   description: 'Install a skill to the shared library on a node.',
   method: 'POST', path: '/api/skills/install',
@@ -64,6 +70,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'plugins',
   name: 'armada_skill_update',
   description: 'Update a skill in the shared library.',
   method: 'POST', path: '/api/skills/update',

--- a/packages/control/src/routes/system.ts
+++ b/packages/control/src/routes/system.ts
@@ -18,6 +18,7 @@ const pkgPath = resolve(__dirname, '..', '..', '..', '..', 'package.json');
 const armadaVersion: string = JSON.parse(readFileSync(pkgPath, 'utf-8')).version;
 
 registerToolDef({
+  category: 'system',
   name: 'armada_health',
   description: 'Quick health check — agent count and uptime.',
   method: 'GET', path: '/api/health',
@@ -25,6 +26,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'system',
   name: 'armada_system_status',
   description: 'Full armada system status — agent counts, node health, resource usage (CPU, memory, disk).',
   method: 'GET', path: '/api/status',

--- a/packages/control/src/routes/tasks.ts
+++ b/packages/control/src/routes/tasks.ts
@@ -605,6 +605,7 @@ router.delete('/:id/comments/:commentId', requireScope('tasks:write'), (req, res
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_tasks_list',
   description: 'List recent armada tasks with optional filtering by agent or status',
   method: 'GET',
@@ -618,6 +619,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_detail',
   description: 'Get details of a specific armada task',
   method: 'GET',
@@ -629,6 +631,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_create',
   description: 'Record a new armada task',
   method: 'POST',
@@ -645,6 +648,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_update',
   description: 'Update a armada task status',
   method: 'PUT',
@@ -658,6 +662,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_unblock',
   description: 'Unblock a blocked task, restoring it to pending or running',
   method: 'POST',
@@ -669,6 +674,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_comments_list',
   description: 'List comments/annotations on a armada task',
   method: 'GET',
@@ -680,6 +686,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_comment_add',
   description: 'Add a comment/annotation to a armada task',
   method: 'POST',
@@ -693,6 +700,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_comment_delete',
   description: 'Delete a comment from a armada task',
   method: 'DELETE',
@@ -705,6 +713,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_steer',
   description: 'Inject a message into an agent\'s active task. Use this to course-correct, provide additional info, or tell the agent to retry something mid-task.',
   method: 'POST',
@@ -717,6 +726,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_task_send',
   description: 'Send a task to an agent via the control plane relay. Resolves agent to instance to node.',
   method: 'POST',
@@ -729,6 +739,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_escalate',
   description: 'Escalate a task — horizontally to a peer agent with different skills, or vertically to a human operator for a decision.',
   method: 'POST',
@@ -745,6 +756,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tasks',
   name: 'armada_escalation_resolve',
   description: 'Resolve a vertically escalated task. Approve to resume, reject to fail, or reassign to another agent.',
   method: 'POST',

--- a/packages/control/src/routes/template-sync.ts
+++ b/packages/control/src/routes/template-sync.ts
@@ -8,6 +8,7 @@ import type { NodeManager } from '../node-manager.js';
 import type { Agent, Template, TemplateSkill } from '@coderage-labs/armada-shared';
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_drift',
   description: 'Check if an agent\'s running config has drifted from its template. Shows differences.',
   method: 'GET', path: '/api/templates/:name/drift',
@@ -17,6 +18,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_sync',
   description: 'Sync an agent\'s config back to match its template. Fixes drift.',
   method: 'POST', path: '/api/templates/:name/sync',

--- a/packages/control/src/routes/templates.ts
+++ b/packages/control/src/routes/templates.ts
@@ -15,6 +15,7 @@ import { workingCopy } from '../services/working-copy.js';
 const router = Router();
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_templates',
   description: 'List all armada templates. Shows template ID, name, role, and model.',
   method: 'GET', path: '/api/templates',
@@ -23,6 +24,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_get',
   description: 'Get a single armada template by ID. Returns full template details including soul, agents, plugins, etc.',
   method: 'GET', path: '/api/templates/:id',
@@ -33,6 +35,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_create',
   description: 'Create a new armada template. Defines the blueprint for spawning agents.',
   method: 'POST', path: '/api/templates',
@@ -49,6 +52,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_update',
   description: 'Update an existing armada template. Only provided fields are changed.',
   method: 'PUT', path: '/api/templates/:id',
@@ -66,6 +70,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_delete',
   description: 'Delete a armada template by ID.',
   method: 'DELETE', path: '/api/templates/:id',
@@ -264,6 +269,7 @@ router.post('/:id/sync', requireScope('templates:write'), (req, res, next) => {
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_drift',
   description: 'Check which agents have drifted from their template. Shows field-level differences.',
   method: 'GET', path: '/api/templates/:id/drift',
@@ -274,6 +280,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_template_sync',
   description: 'Sync a template to all agents using it. Stages pending mutations and creates/updates a draft changeset.',
   method: 'POST', path: '/api/templates/:id/sync',

--- a/packages/control/src/routes/tools.ts
+++ b/packages/control/src/routes/tools.ts
@@ -4,6 +4,7 @@ import { registerToolDef } from '../utils/tool-registry.js';
 import type { NodeManager } from '../node-manager.js';
 
 registerToolDef({
+  category: 'tools',
   name: 'armada_tools_ensure',
   description: 'Ensure binary tools are installed on a node for agents. Uses eget to download from GitHub releases.',
   method: 'POST',
@@ -15,6 +16,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tools',
   name: 'armada_tools_list',
   description: 'List binary tools installed on the node agent.',
   method: 'GET',
@@ -23,6 +25,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'tools',
   name: 'armada_tools_update',
   description: 'Force re-download the latest version of a specific tool on the node.',
   method: 'POST',

--- a/packages/control/src/routes/triage.ts
+++ b/packages/control/src/routes/triage.ts
@@ -3,6 +3,7 @@ import { requireScope } from '../middleware/scopes.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 
 registerToolDef({
+  category: 'issues',
   name: 'armada_triage_dismiss',
   description: 'Dismiss a GitHub issue — mark it as triaged and optionally close it on GitHub with a wontfix label.',
   method: 'POST',
@@ -17,6 +18,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'issues',
   name: 'armada_triage_scan',
   description: 'Scan all projects for untriaged GitHub issues and dispatch triage to PM agents.',
   method: 'POST', path: '/api/triage/scan',
@@ -25,6 +27,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'issues',
   name: 'armada_triage_issue',
   description: 'Triage a specific GitHub issue. If project has a PM agent, it triages. Otherwise returns to operator.',
   method: 'POST', path: '/api/triage/issue',
@@ -36,6 +39,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'issues',
   name: 'armada_triage_mark',
   description: 'Mark an issue as triaged (when operator handles it manually).',
   method: 'POST', path: '/api/triage/mark',
@@ -47,6 +51,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'issues',
   name: 'armada_triage_dispatch',
   description: 'Triage a GitHub issue by selecting a workflow and launching it. Auto-populates issue details as template variables. Marks the issue as triaged.',
   method: 'POST',

--- a/packages/control/src/routes/users.ts
+++ b/packages/control/src/routes/users.ts
@@ -13,6 +13,7 @@ const router = Router();
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_users_list',
   description: 'List all users.',
   method: 'GET',
@@ -22,6 +23,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_get',
   description: 'Get a armada user by ID or name.',
   method: 'GET',
@@ -33,6 +35,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_create',
   description: 'Create a new armada user.',
   method: 'POST',
@@ -49,6 +52,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_update',
   description: 'Update a armada user.',
   method: 'PUT',
@@ -66,6 +70,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_delete',
   description: 'Delete a armada user.',
   method: 'DELETE',
@@ -200,6 +205,7 @@ router.get('/:id/projects', requireScope('users:read'), (req, res) => {
 // ── Avatar routes ────────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_avatar_generate',
   description: 'Generate an AI avatar for a armada user.',
   method: 'POST', path: '/api/users/:id/avatar/generate',
@@ -208,6 +214,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'admin',
   name: 'armada_user_avatar_delete',
   description: 'Delete the avatar for a armada user.',
   method: 'DELETE', path: '/api/users/:id/avatar',

--- a/packages/control/src/routes/webhooks-inbound.ts
+++ b/packages/control/src/routes/webhooks-inbound.ts
@@ -19,6 +19,7 @@ import { eventBus } from '../infrastructure/event-bus.js';
 const mgmtRouter = Router();
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_inbound_webhooks_list',
   description: 'List all configured inbound webhooks.',
   method: 'GET',
@@ -27,6 +28,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_inbound_webhooks_create',
   description: 'Create an inbound webhook that external services can POST to, triggering a workflow, task, or event.',
   method: 'POST',
@@ -41,6 +43,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_inbound_webhooks_update',
   description: 'Update an inbound webhook configuration.',
   method: 'PUT',
@@ -57,6 +60,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_inbound_webhooks_delete',
   description: 'Delete an inbound webhook.',
   method: 'DELETE',

--- a/packages/control/src/routes/webhooks.ts
+++ b/packages/control/src/routes/webhooks.ts
@@ -14,6 +14,7 @@ const router = Router();
 // ── Tool definitions ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_list',
   description: 'List all configured webhooks.',
   method: 'GET',
@@ -23,6 +24,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_create',
   description: 'Create a new webhook that receives POST notifications for armada events.',
   method: 'POST',
@@ -36,6 +38,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_update',
   description: 'Update a webhook configuration.',
   method: 'PUT',
@@ -51,6 +54,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_delete',
   description: 'Delete a webhook.',
   method: 'DELETE',
@@ -62,6 +66,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_test',
   description: 'Send a test payload to a webhook to verify it is reachable.',
   method: 'POST',
@@ -73,6 +78,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'integrations',
   name: 'armada_webhooks_events',
   description: 'List all available webhook event types, grouped by category.',
   method: 'GET',

--- a/packages/control/src/routes/workflow-artifacts.ts
+++ b/packages/control/src/routes/workflow-artifacts.ts
@@ -19,6 +19,7 @@ import { registerToolDef } from '../utils/tool-registry.js';
 // ── Tool definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_artifact_upload',
   description: 'Upload a file as a workflow artifact. Other steps can download it later. Use this to share code files, configs, reports between workflow steps. Content must be base64-encoded.',
   method: 'POST',
@@ -34,6 +35,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_artifact_list',
   description: 'List all artifacts for a workflow run. Shows files uploaded by all completed steps.',
   method: 'GET',
@@ -46,6 +48,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_artifact_download',
   description: 'Download a workflow artifact by ID. Returns the file content.',
   method: 'GET',

--- a/packages/control/src/routes/workflows.ts
+++ b/packages/control/src/routes/workflows.ts
@@ -15,6 +15,7 @@ import type { TelegramNotification } from '../services/user-notifier.js';
 // ── Tool definitions ────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflows_list',
   description: 'List all workflows. Optional projectId filter.',
   method: 'GET', path: '/api/workflows',
@@ -23,6 +24,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_get',
   description: 'Get a workflow by ID. Returns steps, projectIds, enabled status.',
   method: 'GET', path: '/api/workflows/:id',
@@ -31,6 +33,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_create',
   description: 'Create a new workflow with steps and project assignments.',
   method: 'POST', path: '/api/workflows',
@@ -44,6 +47,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_update',
   description: 'Update a workflow (name, description, steps, enabled, projectIds).',
   method: 'PUT', path: '/api/workflows/:id',
@@ -59,6 +63,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_delete',
   description: 'Delete a workflow.',
   method: 'DELETE', path: '/api/workflows/:id',
@@ -67,6 +72,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run',
   description: 'Start a workflow run. Dispatches steps to agents by role.',
   method: 'POST', path: '/api/workflows/:id/run',
@@ -80,6 +86,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_runs',
   description: 'List recent runs for a workflow.',
   method: 'GET', path: '/api/workflows/:id/runs',
@@ -91,6 +98,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_get',
   description: 'Get details of a workflow run including step outputs and context.',
   method: 'GET', path: '/api/workflows/runs/:runId',
@@ -99,6 +107,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_steps',
   description: 'Get step runs for a workflow run.',
   method: 'GET', path: '/api/workflows/runs/:runId/steps',
@@ -107,6 +116,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_approve',
   description: 'Approve a manual gate step to continue the workflow.',
   method: 'POST', path: '/api/workflows/runs/:runId/approve/:stepId',
@@ -118,6 +128,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_reject',
   description: 'Reject a manual gate step. Fails the run if the gate is required, skips downstream if optional.',
   method: 'POST', path: '/api/workflows/runs/:runId/reject/:stepId',
@@ -130,6 +141,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_retry',
   description: 'Retry a workflow step with optional feedback. Cascades reset to downstream steps.',
   method: 'POST', path: '/api/workflows/runs/:runId/retry/:stepId',
@@ -142,6 +154,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_cancel',
   description: 'Cancel a workflow run.',
   method: 'POST', path: '/api/workflows/runs/:runId/cancel',
@@ -150,6 +163,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_context',
   description: 'Get the full workflow context for a run — all steps, their outputs, agents, and rework history. Agents use this to inspect the workflow state.',
   method: 'GET', path: '/api/workflows/runs/:runId/context',
@@ -158,6 +172,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_run_rework',
   description: 'Request rework on a previously completed step. The requesting step is paused, the target step is reset and re-dispatched with feedback.',
   method: 'POST', path: '/api/workflows/runs/:runId/rework',
@@ -171,6 +186,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_runs_active',
   description: 'Get all active (running/paused) workflow runs with step data.',
   method: 'GET', path: '/api/workflows/runs/active',
@@ -179,6 +195,7 @@ registerToolDef({
 });
 
 registerToolDef({
+  category: 'workflows',
   name: 'armada_workflow_runs_recent',
   description: 'Get completed/failed/cancelled workflow runs from the last 24 hours.',
   method: 'GET', path: '/api/workflows/runs/recent',

--- a/packages/control/src/routes/worktrees.ts
+++ b/packages/control/src/routes/worktrees.ts
@@ -15,6 +15,7 @@ const router = Router();
 // ── Tool definition ─────────────────────────────────────────────────
 
 registerToolDef({
+  category: 'git',
   name: 'armada_worktrees',
   description: 'List active Git worktrees created for workflow step isolation. Shows step ID, branch, path, and creation time.',
   method: 'GET',

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -145,6 +145,7 @@ export function initWorkflowDispatcher() {
         callbackUrl: `${callbackBaseUrl}/api/tasks/${opts.taskId}/result`,
         projectId: opts.projectId,
         ...(agent.targetAgent && { targetAgent: agent.targetAgent }),
+        ...(opts.toolCategories?.length && { toolCategories: opts.toolCategories }),
       });
 
       const resp = await node.relayRequest(containerName, 'POST', '/armada/task', body) as any;

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -37,6 +37,7 @@ interface WorkflowStep {
   loopBackToStep?: string;
   maxLoopIterations?: number;
   isolateGit?: boolean;
+  toolCategories?: string[];
 }
 interface RetryState {
   retryCount: number;
@@ -197,6 +198,8 @@ interface DispatchFn {
     taskId: string;
     /** If true, an isolated Git worktree should be created before the step runs */
     isolateGit?: boolean;
+    /** Restrict tool loading to these categories for this step */
+    toolCategories?: string[];
   }): Promise<{ agentName: string; armadaTaskId: string } | { error: string }>;
 }
 
@@ -460,6 +463,7 @@ async function dispatchStep(
       stepId: step.id,
       taskId,
       isolateGit: step.isolateGit,
+      toolCategories: step.toolCategories,
     });
 
     if ('error' in result) {

--- a/packages/control/src/utils/tool-registry.ts
+++ b/packages/control/src/utils/tool-registry.ts
@@ -30,6 +30,8 @@ export interface ToolDefinition {
   supportsAll?: boolean;
   /** Required scope to access this tool. Used for filtering in /api/meta/tools */
   scope?: string;
+  /** Logical category for on-demand subset loading (e.g. 'instances', 'issues', 'git') */
+  category?: string;
 }
 
 const _tools: ToolDefinition[] = [];
@@ -51,4 +53,13 @@ export function registerToolDef(def: ToolDefinition): void {
  */
 export function getToolDefs(): ToolDefinition[] {
   return [..._tools];
+}
+
+/**
+ * Get tool definitions filtered by one or more categories.
+ * Returns only tools whose category is in the given list.
+ */
+export function getToolDefsByCategories(categories: string[]): ToolDefinition[] {
+  if (!categories.length) return [..._tools];
+  return _tools.filter(t => t.category !== undefined && categories.includes(t.category));
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -512,6 +512,13 @@ export interface WorkflowStep {
    * operate on the same repository.
    */
   isolateGit?: boolean;
+  /**
+   * Restrict tool loading to these categories for this step.
+   * When set, the agent plugin only loads tools from the specified categories
+   * instead of all available tools. Reduces context window usage.
+   * E.g. ['git', 'issues'] loads only git and issue-tracking tools.
+   */
+  toolCategories?: string[];
 }
 
 export interface Workflow {

--- a/packages/ui/src/pages/WorkflowDetail.tsx
+++ b/packages/ui/src/pages/WorkflowDetail.tsx
@@ -128,6 +128,13 @@ function StepEditorDialog({
   const [loopUntilApproved, setLoopUntilApproved] = useState(step?.loopUntilApproved ?? false);
   const [loopBackToStep, setLoopBackToStep] = useState(step?.loopBackToStep ?? '');
   const [maxLoopIterations, setMaxLoopIterations] = useState(step?.maxLoopIterations ?? 5);
+  const [toolCategories, setToolCategories] = useState<string[]>(step?.toolCategories || []);
+
+  const TOOL_CATEGORIES = [
+    'instances', 'projects', 'issues', 'workflows', 'git', 'changesets',
+    'integrations', 'notifications', 'system', 'hierarchy', 'plugins',
+    'admin', 'tasks', 'tools',
+  ];
 
   useEffect(() => {
     apiFetch<{ rules: Record<string, string[]> }>('/api/hierarchy')
@@ -177,6 +184,7 @@ function StepEditorDialog({
       loopUntilApproved: loopUntilApproved || undefined,
       loopBackToStep: loopUntilApproved && loopBackToStep.trim() ? loopBackToStep.trim() : undefined,
       maxLoopIterations: loopUntilApproved ? maxLoopIterations : undefined,
+      toolCategories: toolCategories.length > 0 ? toolCategories : undefined,
     });
   }
 
@@ -384,6 +392,46 @@ function StepEditorDialog({
               </div>
             </div>
           )}
+
+          {/* Tool Categories */}
+          <div className="border-t border-zinc-700/50 pt-3">
+            <div className="mb-2">
+              <div className="text-sm text-zinc-300">Tool Categories</div>
+              <div className="text-xs text-zinc-500">Restrict which tools the agent can use (empty = all tools)</div>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {TOOL_CATEGORIES.map(cat => {
+                const selected = toolCategories.includes(cat);
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => {
+                      setToolCategories(prev =>
+                        selected ? prev.filter(c => c !== cat) : [...prev, cat]
+                      );
+                    }}
+                    className={`px-2.5 py-1 rounded-md text-xs font-medium transition-all ${
+                      selected
+                        ? 'bg-violet-500/30 text-violet-300 border border-violet-500/50'
+                        : 'bg-zinc-800/50 text-zinc-500 border border-zinc-700 hover:border-zinc-600 hover:text-zinc-400'
+                    }`}
+                  >
+                    {cat}
+                  </button>
+                );
+              })}
+            </div>
+            {toolCategories.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setToolCategories([])}
+                className="mt-1.5 text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
         </div>
 
         <DialogFooter>

--- a/plugins/agent/src/index.ts
+++ b/plugins/agent/src/index.ts
@@ -355,27 +355,30 @@ function getCurrentAgentName(): string {
   return _config?.instanceName ?? 'unknown';
 }
 
-// Cache of agent names whose tools have already been loaded
+// Cache of agent+categories combos whose tools have already been loaded
 const _agentToolsLoaded = new Set<string>();
 
 /**
  * Ensure tools are loaded for a specific agent name (per-agent lazy loading).
- * No-ops if already loaded for that agent.
+ * Optionally filter by tool categories for workflow step scoping.
+ * No-ops if already loaded for that agent+categories combo.
  */
-async function ensureAgentTools(api: any, agentName: string): Promise<void> {
-  if (_agentToolsLoaded.has(agentName)) return;
-  await loadarmadaTools(api, agentName);
-  _agentToolsLoaded.add(agentName);
+async function ensureAgentTools(api: any, agentName: string, categories?: string[]): Promise<void> {
+  const cacheKey = categories?.length ? `${agentName}:${[...categories].sort().join(',')}` : agentName;
+  if (_agentToolsLoaded.has(cacheKey)) return;
+  await loadarmadaTools(api, agentName, categories);
+  _agentToolsLoaded.add(cacheKey);
 }
 
-async function loadarmadaTools(api: any, agentName?: string) {
+async function loadarmadaTools(api: any, agentName?: string, categories?: string[]) {
   // Require proxyUrl — all control plane communication must go through the node agent relay
   if (!_config || !getApiBaseUrl()) return;
 
   try {
-    const toolsUrl = agentName
-      ? `${getApiBaseUrl()}/api/meta/tools?agent=${encodeURIComponent(agentName)}`
-      : `${getApiBaseUrl()}/api/meta/tools`;
+    const params = new URLSearchParams();
+    if (agentName) params.set('agent', agentName);
+    if (categories?.length) params.set('categories', categories.join(','));
+    const toolsUrl = `${getApiBaseUrl()}/api/meta/tools?${params}`;
     const resp = await fetch(toolsUrl, {
       headers: {
         ...getToolAuthHeaders(),
@@ -704,7 +707,7 @@ export default function register(api: any) {
     path: '/armada/task',
     handler: async (req: IncomingMessage, res: ServerResponse) => {
       const body = await readBody(req);
-      const { taskId, from, fromRole, message, callbackUrl, attachments, project, targetAgent } = body;
+      const { taskId, from, fromRole, message, callbackUrl, attachments, project, targetAgent, toolCategories } = body;
 
       if (!taskId || !from || !message || !callbackUrl) {
         return sendJson(res, 400, { error: 'Missing required fields: taskId, from, message, callbackUrl' });
@@ -712,9 +715,11 @@ export default function register(api: any) {
 
       if (_draining) return sendJson(res, 503, { error: 'Instance is draining' });
 
-      // Ensure tools are loaded for the target agent (lazy, cached per-agent name)
+      // Ensure tools are loaded for the target agent (lazy, cached per-agent+categories combo)
+      // When toolCategories is set, only load tools from those categories (reduces context window usage)
+      const categories = Array.isArray(toolCategories) ? toolCategories : undefined;
       if (targetAgent && getApiBaseUrl()) {
-        await ensureAgentTools(api, targetAgent).catch(err => {
+        await ensureAgentTools(api, targetAgent, categories).catch(err => {
           _logger.warn(`[armada-agent] Failed to load tools for agent ${targetAgent}: ${err.message}`);
         });
       }


### PR DESCRIPTION
Closes #128

## What
All 204 tools tagged with one of 14 categories. Workflow steps can now specify which tool categories the agent needs, reducing context window usage.

## Categories
instances, projects, issues, workflows, git, changesets, integrations, notifications, system, hierarchy, plugins, admin, tasks, tools

## Changes
- `ToolDefinition.category` field + server-side filtering via `?categories=`
- All 204 `registerToolDef` calls tagged across 38 route files
- `WorkflowStep.toolCategories` flows through dispatcher → plugin
- Plugin caches per agent+categories combo
- UI: clickable category chips on workflow step editor

## Impact
A coding step with `toolCategories: ['git', 'issues']` loads ~15 tools instead of 68+. Significant token savings per workflow step.