### PR TITLE
fix: resolve all TypeScript compilation errors across monorepo

### DIFF
--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -101,7 +101,7 @@ function resolveProjectManager(projectId: string): { name: string; role: string 
 export async function triageIssue(
   projectId: string,
   issue: GitHubIssue,
-): Promise<{ triaged: boolean; by: 'pm' | 'operator'; result?: TriageResult; runId?: string }> {
+): Promise<{ triaged: boolean; by: 'pm' | 'operator' | string; result?: TriageResult; runId?: string }> {
   if (isIssueTriaged(projectId, issue.number)) {
     return { triaged: false, by: 'operator' };
   }

--- a/packages/ui/e2e/global-setup.ts
+++ b/packages/ui/e2e/global-setup.ts
@@ -13,7 +13,7 @@ export default async function globalSetup() {
   await page.evaluate((token: string) => {
     document.cookie = 'armada_authed=true; path=/; max-age=3600';
     localStorage.setItem('armada_token', token);
-  }, process.env.ARMADA_TOKEN || process.env.ARMADA_TOKEN ?? 'test-token');
+  }, process.env.ARMADA_TOKEN ?? 'test-token');
 
   await context.storageState({ path: 'e2e/.auth/state.json' });
   await browser.close();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,13 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "dist"
-  }
+    "outDir": "dist",
+    "jsx": "react-jsx"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "plugins/**",
+    "packages/ui/e2e/**"
+  ]
 }


### PR DESCRIPTION
Fixes all TS errors so `npx tsc --noEmit` passes clean from the repo root.

### Changes
- **triage.ts**: Fix return type to accept user triager names (`string` union instead of just `'pm' | 'operator'`)
- **global-setup.ts**: Fix redundant duplicate env var reference with mixed `||` / `??` operators
- **tsconfig.json**: Add `jsx: react-jsx` to root config, exclude `plugins/` and `e2e/` (they have their own tsconfigs with different module resolution)
- **plugins/shared**: Must be built before agent/control plugins can compile (not a code change, but a build order dependency)

### Verification
- `npx tsc --noEmit` = **0 errors** (was ~200+)
- `npx tsc -p plugins/agent/tsconfig.json --noEmit` = **0 errors**
- `npx tsc -p plugins/control/tsconfig.json --noEmit` = **0 errors**
- 163 unit tests pass