### PR TITLE
feat: auto-dispatch unblocked issues on workflow completion

### DIFF
--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -658,6 +658,18 @@ export const workflowArtifacts = sqliteTable('workflow_artifacts', {
   createdAt: text('created_at').notNull(),
 });
 
+// ── issue_dependencies (#159) ────────────────────────────────────────
+export const issueDependencies = sqliteTable('issue_dependencies', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull(),
+  repo: text('repo').notNull(),
+  issueNumber: integer('issue_number').notNull(),
+  blockedByRepo: text('blocked_by_repo').notNull(),
+  blockedByIssueNumber: integer('blocked_by_issue_number').notNull(),
+  resolved: integer('resolved').notNull().default(0),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
 // ── notification_channels (#512) ────────────────────────────────────
 export const notificationChannels = sqliteTable('notification_channels', {
   id: text('id').primaryKey(),

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -449,6 +449,26 @@ const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_workflow_artifacts_step_id ON workflow_artifacts(run_id, step_id)',
     ],
   },
+
+  // ── issue_dependencies (#159) ─────────────────────────────────────
+  {
+    version: 38,
+    description: 'Create issue_dependencies table for auto-dispatch on completion (#159)',
+    sql: [
+      `CREATE TABLE IF NOT EXISTS issue_dependencies (
+        id                     TEXT PRIMARY KEY,
+        project_id             TEXT NOT NULL,
+        repo                   TEXT NOT NULL,
+        issue_number           INTEGER NOT NULL,
+        blocked_by_repo        TEXT NOT NULL,
+        blocked_by_issue_number INTEGER NOT NULL,
+        resolved               INTEGER NOT NULL DEFAULT 0,
+        created_at             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_issue_deps_blocked_by ON issue_dependencies(blocked_by_repo, blocked_by_issue_number)',
+      'CREATE INDEX IF NOT EXISTS idx_issue_deps_issue ON issue_dependencies(repo, issue_number)',
+    ],
+  },
 ];
 
 /**

--- a/packages/control/src/services/issue-sync.ts
+++ b/packages/control/src/services/issue-sync.ts
@@ -1,6 +1,6 @@
 import { projectsRepo, settingsRepo } from '../repositories/index.js';
 import { getDrizzle } from '../db/drizzle.js';
-import { githubIssueCache, triagedIssues } from '../db/drizzle-schema.js';
+import { githubIssueCache, triagedIssues, issueDependencies } from '../db/drizzle-schema.js';
 import { eq, sql, and } from 'drizzle-orm';
 import { logActivity } from './activity-service.js';
 import { eventBus } from '../infrastructure/event-bus.js';
@@ -57,6 +57,54 @@ function resolveGitHubToken(projectId: string): string {
     console.warn(`[issue-sync] Failed to resolve integration token for project ${projectId}:`, err.message);
   }
   return process.env.GITHUB_TOKEN || '';
+}
+
+/**
+ * Parse "blocked by" / "depends on" references from an issue body and
+ * upsert them into the issue_dependencies table.
+ *
+ * Supported patterns:
+ *   blocked by #123          → same repo
+ *   depends on #123          → same repo
+ *   blocked by owner/repo#123 → cross-repo
+ */
+export function parseDependencies(
+  projectId: string,
+  issueRepo: string,
+  issueNumber: number,
+  body: string,
+): void {
+  if (!body) return;
+
+  const db = getDrizzle();
+  const DEPENDENCY_RE = /(?:blocked by|depends on)\s+(?:([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+))?#(\d+)/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = DEPENDENCY_RE.exec(body)) !== null) {
+    const blockedByRepo = match[1] ? match[1] : issueRepo;
+    const blockedByIssueNumber = parseInt(match[2], 10);
+    if (!blockedByRepo || !blockedByIssueNumber) continue;
+
+    const id = `${projectId}:${issueRepo}:${issueNumber}:${blockedByRepo}:${blockedByIssueNumber}`;
+    db.insert(issueDependencies).values({
+      id,
+      projectId,
+      repo: issueRepo,
+      issueNumber,
+      blockedByRepo,
+      blockedByIssueNumber,
+      resolved: 0,
+    }).onConflictDoUpdate({
+      target: [issueDependencies.id],
+      set: {
+        // Keep resolved state — don't reset if already resolved
+        repo: sql`excluded.repo`,
+        issueNumber: sql`excluded.issue_number`,
+        blockedByRepo: sql`excluded.blocked_by_repo`,
+        blockedByIssueNumber: sql`excluded.blocked_by_issue_number`,
+      },
+    }).run();
+  }
 }
 
 export async function syncProjectIssues(projectId: string): Promise<{ fetched: number }> {
@@ -147,6 +195,11 @@ export async function syncProjectIssues(projectId: string): Promise<{ fetched: n
         cachedAt: sql`excluded.cached_at`,
       },
     }).run();
+  }
+
+  // Parse and upsert issue dependencies from issue bodies
+  for (const issue of allIssues) {
+    parseDependencies(projectId, issue.repo || '', issue.number, issue.body || '');
   }
 
   // Mark cached issues NOT in the fresh response as closed (they were closed/deleted on GitHub)

--- a/packages/control/src/services/triage.ts
+++ b/packages/control/src/services/triage.ts
@@ -624,3 +624,22 @@ eventBus.on('github.new_issues', (event) => {
     console.error('[triage] Auto-triage failed:', err);
   });
 });
+
+// ── Auto-triage unblocked issues (#159) ─────────────────────────────────────
+// When a workflow completes and unblocks a dependent issue, trigger triage for it.
+eventBus.on('issue.unblocked', (event) => {
+  const { projectId, repo, issueNumber } = event.data as { projectId: string; repo: string; issueNumber: number };
+  console.log(`[triage] Auto-triage triggered for unblocked issue #${issueNumber} in ${repo} (project ${projectId})`);
+
+  // Look up the cached issue so we have the full GitHubIssue object
+  const issues = getCachedIssues(projectId);
+  const issue = issues.find(i => i.number === issueNumber && i.repo === repo);
+  if (!issue) {
+    console.warn(`[triage] Unblocked issue #${issueNumber} not found in cache for project ${projectId} — skipping auto-triage`);
+    return;
+  }
+
+  triageIssue(projectId, issue).catch((err: Error) => {
+    console.error(`[triage] Auto-triage of unblocked issue #${issueNumber} failed:`, err.message);
+  });
+});

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -13,13 +13,14 @@
 
 import { randomUUID } from 'node:crypto';
 import { getDrizzle } from '../db/drizzle.js';
-import { workflows as workflowsTable, workflowRuns, workflowStepRuns, workflowProjects } from '../db/drizzle-schema.js';
+import { workflows as workflowsTable, workflowRuns, workflowStepRuns, workflowProjects, issueDependencies } from '../db/drizzle-schema.js';
 import { eq, and, desc, sql, inArray } from 'drizzle-orm';
 import { dispatchWebhook } from './webhook-dispatcher.js';
 import { broadcast } from '../utils/event-bus.js';
 import { getArtifactContextBlock } from '../routes/workflow-artifacts.js';
 import { projectsRepo, agentsRepo, instancesRepo } from '../repositories/index.js';
 import { getNodeClient } from '../infrastructure/node-client.js';
+import { eventBus } from '../infrastructure/event-bus.js';
 
 // Types — mirror shared package types locally to avoid build ordering issues
 interface WorkflowStep {
@@ -406,6 +407,13 @@ async function advanceRun(
           failedStepName: failedStep?.name,
           failureDetail: failedStepRun.output ?? undefined,
         }),
+      });
+    }
+
+    // ── Auto-dispatch unblocked issues (#159) ────────────────────────
+    if (finalStatus === 'completed') {
+      checkAndDispatchUnblockedIssues(run).catch((err: Error) => {
+        console.error('[workflow-engine] Failed to check unblocked issues:', err.message);
       });
     }
   } else if (anyGated) {
@@ -1653,4 +1661,81 @@ export function getGateUpstreamSteps(
     const step = workflow.steps.find(s => s.id === depId);
     return { id: depId, name: step?.name ?? depId };
   });
+}
+
+// ── Auto-dispatch unblocked issues (#159) ────────────────────────────
+
+/**
+ * Called after a workflow run completes successfully.
+ * Marks any dependencies on the completed issue as resolved, then checks
+ * if any previously-blocked issues are now fully unblocked.
+ * If so (and the WIP limit allows), emits an event to trigger triage.
+ */
+async function checkAndDispatchUnblockedIssues(run: WorkflowRun): Promise<void> {
+  const vars = (run.context as any)?._vars ?? {};
+  const issueNumber = vars.issueNumber as number | undefined;
+  const issueRepo = vars.issueRepo as string | undefined;
+
+  if (!issueNumber || !issueRepo) {
+    // Run wasn't triggered by a GitHub issue — nothing to unblock
+    return;
+  }
+
+  const db = getDrizzle();
+
+  // Mark all dependencies where this issue was the blocker as resolved
+  db.run(sql`
+    UPDATE issue_dependencies
+    SET resolved = 1
+    WHERE blocked_by_repo = ${issueRepo}
+      AND blocked_by_issue_number = ${issueNumber}
+      AND resolved = 0
+  `);
+
+  // Find issues that were blocked by this one
+  const dependents = db.select().from(issueDependencies)
+    .where(
+      and(
+        eq(issueDependencies.blockedByRepo, issueRepo),
+        eq(issueDependencies.blockedByIssueNumber, issueNumber),
+      ),
+    )
+    .all();
+
+  if (dependents.length === 0) return;
+
+  for (const dep of dependents) {
+    // Check if ALL blockers for this dependent issue are now resolved
+    const unresolvedCount = db.all(sql`
+      SELECT COUNT(*) as cnt
+      FROM issue_dependencies
+      WHERE repo = ${dep.repo}
+        AND issue_number = ${dep.issueNumber}
+        AND resolved = 0
+    `) as Array<{ cnt: number }>;
+
+    const remaining = unresolvedCount[0]?.cnt ?? 0;
+    if (remaining > 0) {
+      console.log(`[workflow-engine] Issue #${dep.issueNumber} in ${dep.repo} still has ${remaining} unresolved blocker(s) — skipping`);
+      continue;
+    }
+
+    // Check WIP limit for the project
+    const activeRuns = getActiveWorkflowRuns().filter(r => r.projectId === dep.projectId);
+    const project = projectsRepo.get(dep.projectId);
+    const maxConcurrent = project?.maxConcurrent ?? 3;
+
+    if (activeRuns.length >= maxConcurrent) {
+      console.log(`[workflow-engine] WIP limit (${maxConcurrent}) reached for project "${project?.name ?? dep.projectId}" — issue #${dep.issueNumber} will be picked up on next completion`);
+      continue;
+    }
+
+    // All blockers resolved and WIP allows — emit event to trigger triage
+    console.log(`[workflow-engine] Issue #${dep.issueNumber} in ${dep.repo} is now unblocked — emitting issue.unblocked`);
+    eventBus.emit('issue.unblocked', {
+      projectId: dep.projectId,
+      repo: dep.repo,
+      issueNumber: dep.issueNumber,
+    });
+  }
 }


### PR DESCRIPTION
Closes #159

### The triager loop

When a workflow completes, Armada now automatically checks if any blocked issues are unblocked and dispatches them for triage.

### Changes (5 files, 191 additions)

1. **issue_dependencies table** — new migration v38, tracks blocker relationships between issues
2. **Dependency parsing** — `parseDependencies()` in issue-sync extracts `blocked by #X` / `depends on owner/repo#X` from issue bodies during sync
3. **Completion hook** — `checkAndDispatchUnblockedIssues()` fires on workflow completion: marks blocker resolved → finds dependents → checks all blockers cleared → checks WIP limit → emits `issue.unblocked`
4. **Triage listener** — `issue.unblocked` event triggers auto-triage for the newly ready issue

### Flow
```
Workflow completes (#1)
  → mark #1 as resolved in issue_dependencies
  → find issues blocked by #1 (e.g. #2, #3)
  → for each: are ALL blockers resolved?
    → yes + under WIP limit → emit issue.unblocked → auto-triage
    → no → wait for remaining blockers
```

0 TS errors, 163 tests pass.