### PR TITLE
feat: pre-provision workspace before dispatching workflow steps

### DIFF
--- a/packages/control/src/infrastructure/ws-node-client.ts
+++ b/packages/control/src/infrastructure/ws-node-client.ts
@@ -381,6 +381,31 @@ export class WsNodeClient {
     await this.send('file.delete', { path, recursive });
   }
 
+  // === Workspace Provisioning ===
+
+  /**
+   * Clone a git repo into an instance container and create a feature branch.
+   * Runs `git clone` + `git checkout -b` (+ optional `npm install`) inside the container.
+   *
+   * @param instanceName  Instance name (without the armada-instance- prefix)
+   * @param repo          GitHub repo in "owner/repo" format
+   * @param branch        Branch name to create in the cloned repo
+   * @param path          Optional target path inside the container (default: /tmp/work/<repoName>)
+   */
+  async cloneWorkspace(
+    instanceName: string,
+    repo: string,
+    branch: string,
+    path?: string,
+  ): Promise<{ path: string; branch: string; status: string }> {
+    const containerName = `armada-instance-${instanceName}`;
+    return this.send('workspace.clone', { instanceId: containerName, repo, branch, path }, 300_000) as Promise<{
+      path: string;
+      branch: string;
+      status: string;
+    }>;
+  }
+
   // === Instance event relay ===
 
   /**

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -135,6 +135,31 @@ export function initWorkflowDispatcher() {
         }
       }
 
+      // ── Workspace pre-provisioning ────────────────────────────────────
+      // For development steps with an issueRepo, clone the repo into the
+      // instance container before sending the task so the agent can start
+      // work immediately without needing to clone manually.
+      if (opts.role === 'development' && opts.vars?.issueRepo) {
+        const issueRepo = opts.vars.issueRepo as string;
+        const issueNumber = opts.vars.issueNumber as number | undefined;
+        const issueTitle = opts.vars.issueTitle as string | undefined;
+        const repoName = issueRepo.split('/').pop() || 'work';
+        const slugTitle = issueTitle
+          ? issueTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 30).replace(/-+$/, '')
+          : 'impl';
+        const branch = `feature/${issueNumber ? `${issueNumber}-` : ''}${slugTitle}`;
+        const workPath = `/tmp/work/${repoName}`;
+
+        try {
+          const wsNode = getNodeClient(instance.nodeId);
+          await wsNode.cloneWorkspace(instance.name, issueRepo, branch, workPath);
+          console.log(`[workflow-dispatcher] Provisioned workspace for step "${opts.stepId}": ${workPath} (branch: ${branch})`);
+        } catch (err: any) {
+          // Non-fatal — the agent can still clone manually
+          console.warn(`[workflow-dispatcher] Workspace provisioning failed for step "${opts.stepId}": ${err.message}`);
+        }
+      }
+
       // Use instance proxyUrl for callback so agents can reach the control plane through the node proxy
       const callbackBaseUrl = process.env.ARMADA_AGENT_GATEWAY_URL || 'http://armada-node:3002';
       const body = JSON.stringify({

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -201,6 +201,8 @@ interface DispatchFn {
     isolateGit?: boolean;
     /** Restrict tool loading to these categories for this step */
     toolCategories?: string[];
+    /** Resolved workflow template variables — used for workspace pre-provisioning */
+    vars?: Record<string, any>;
   }): Promise<{ agentName: string; armadaTaskId: string } | { error: string }>;
 }
 
@@ -543,6 +545,7 @@ async function dispatchStep(
       taskId,
       isolateGit: step.isolateGit,
       toolCategories: step.toolCategories,
+      vars: mergedUserVars,
     });
 
     if ('error' in result) {

--- a/packages/node/src/handlers/workspace.ts
+++ b/packages/node/src/handlers/workspace.ts
@@ -1,0 +1,169 @@
+/**
+ * Workspace handler — pre-provisions git workspaces inside instance containers
+ * before workflow steps are dispatched.
+ *
+ * Command: workspace.clone
+ * Params:  { instanceId: string, repo: string, branch: string, path?: string }
+ * Returns: { path: string, branch: string, status: 'ready' }
+ */
+
+import Docker from 'dockerode';
+import type { CommandMessage, ResponseMessage } from '@coderage-labs/armada-shared';
+import { WsErrorCode } from '@coderage-labs/armada-shared';
+
+const docker = new Docker({ socketPath: '/var/run/docker.sock' });
+
+/** Run a shell command inside a container and return stdout + stderr as a string. */
+async function containerExec(containerId: string, cmd: string[]): Promise<{ exitCode: number; output: string }> {
+  const container = docker.getContainer(containerId);
+  const exec = await container.exec({
+    Cmd: cmd,
+    AttachStdout: true,
+    AttachStderr: true,
+    User: 'node',
+  });
+
+  return new Promise((resolve, reject) => {
+    exec.start({ hijack: true, stdin: false }, (err: Error | null, stream: NodeJS.ReadableStream | undefined) => {
+      if (err) return reject(err);
+      if (!stream) return resolve({ exitCode: 0, output: '' });
+
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('error', reject);
+      stream.on('end', async () => {
+        const raw = Buffer.concat(chunks);
+        // Docker multiplexed stream: each frame has an 8-byte header
+        // Byte 0: stream type (0=stdin, 1=stdout, 2=stderr)
+        // Bytes 4-7: payload size (big-endian uint32)
+        let output = '';
+        let offset = 0;
+        while (offset < raw.length) {
+          if (offset + 8 > raw.length) break;
+          const size = raw.readUInt32BE(offset + 4);
+          const payload = raw.slice(offset + 8, offset + 8 + size);
+          output += payload.toString('utf-8');
+          offset += 8 + size;
+        }
+
+        try {
+          const inspectResult = await exec.inspect();
+          resolve({ exitCode: inspectResult.ExitCode ?? 0, output: output.trim() });
+        } catch {
+          resolve({ exitCode: 0, output: output.trim() });
+        }
+      });
+    });
+  });
+}
+
+export async function handleWorkspaceClone(msg: CommandMessage): Promise<ResponseMessage> {
+  const params = msg.params as {
+    instanceId: string;
+    repo: string;
+    branch: string;
+    path?: string;
+  };
+
+  const { instanceId, repo, branch } = params;
+  if (!instanceId || !repo || !branch) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: 'instanceId, repo, and branch are required',
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+
+  const repoName = repo.split('/').pop() || 'work';
+  const workPath = params.path || `/tmp/work/${repoName}`;
+
+  console.log(`[workspace] Cloning ${repo} into ${instanceId}:${workPath} (branch: ${branch})`);
+
+  try {
+    // Ensure parent directory exists
+    const mkdirResult = await containerExec(instanceId, ['mkdir', '-p', workPath]);
+    if (mkdirResult.exitCode !== 0) {
+      console.warn(`[workspace] mkdir failed (exit ${mkdirResult.exitCode}): ${mkdirResult.output}`);
+    }
+
+    // Clone the repo
+    const cloneResult = await containerExec(instanceId, [
+      'git', 'clone', `https://github.com/${repo}.git`, workPath,
+    ]);
+
+    if (cloneResult.exitCode !== 0) {
+      return {
+        type: 'response',
+        id: msg.id,
+        status: 'error',
+        error: `git clone failed: ${cloneResult.output}`,
+        code: WsErrorCode.UNKNOWN,
+      };
+    }
+
+    // Create and checkout the branch
+    const checkoutResult = await containerExec(instanceId, [
+      'git', '-C', workPath, 'checkout', '-b', branch,
+    ]);
+
+    if (checkoutResult.exitCode !== 0) {
+      // Branch might already exist — try checking it out without -b
+      const checkoutExisting = await containerExec(instanceId, [
+        'git', '-C', workPath, 'checkout', branch,
+      ]);
+      if (checkoutExisting.exitCode !== 0) {
+        console.warn(`[workspace] git checkout failed: ${checkoutExisting.output}`);
+        // Non-fatal — the repo is still cloned, agent can handle the branch
+      }
+    }
+
+    // Check if package.json exists and run npm install if so
+    const checkPkg = await containerExec(instanceId, [
+      'sh', '-c', `test -f "${workPath}/package.json" && echo "yes" || echo "no"`,
+    ]);
+
+    if (checkPkg.output.trim() === 'yes') {
+      console.log(`[workspace] Found package.json in ${workPath} — running npm install`);
+      const npmResult = await containerExec(instanceId, [
+        'npm', 'install', '--prefix', workPath,
+      ]);
+      if (npmResult.exitCode !== 0) {
+        console.warn(`[workspace] npm install failed (non-fatal): ${npmResult.output}`);
+      }
+    }
+
+    console.log(`[workspace] Workspace ready at ${instanceId}:${workPath}`);
+
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { path: workPath, branch, status: 'ready' },
+    };
+  } catch (err: any) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: `Workspace clone failed: ${err.message}`,
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+}
+
+export async function handleWorkspaceCommand(msg: CommandMessage): Promise<ResponseMessage> {
+  switch (msg.action) {
+    case 'workspace.clone':
+      return handleWorkspaceClone(msg);
+    default:
+      return {
+        type: 'response',
+        id: msg.id,
+        status: 'error',
+        error: `Unknown workspace action: ${msg.action}`,
+        code: WsErrorCode.UNKNOWN,
+      };
+  }
+}

--- a/packages/node/src/ws/command-handler.ts
+++ b/packages/node/src/ws/command-handler.ts
@@ -14,6 +14,7 @@ import { handleSystemCommand } from '../handlers/system.js';
 import { handleToolCommand } from '../handlers/tools.js';
 import { handleRelayCommand } from '../handlers/relay.js';
 import { handleLogsCommand, type LogsHandlerContext } from '../handlers/logs.js';
+import { handleWorkspaceCommand } from '../handlers/workspace.js';
 import { subscribeToInstanceEvents, unsubscribeFromInstanceEvents } from '../handlers/events.js';
 import { loadCredentials, saveCredentials, CREDENTIALS_PATH } from '../credentials.js';
 import { IdempotencyCache } from './idempotency-cache.js';
@@ -171,6 +172,7 @@ async function route(msg: CommandMessage, ctx?: ContainerHandlerContext & LogsHa
     if (action.startsWith('tool.')) return await handleToolCommand(msg);
     if (action === 'instance.relay') return await handleRelayCommand(msg);
     if (action.startsWith('logs.')) return await handleLogsCommand(msg, ctx);
+    if (action.startsWith('workspace.')) return await handleWorkspaceCommand(msg);
 
     return {
       type: 'response',


### PR DESCRIPTION
Closes #165

### What it does
Before dispatching a development step, the workflow engine now pre-provisions the workspace:
1. Node agent execs `git clone` + `git checkout -b` + `npm install` inside the instance container
2. Agent receives the task with workspace ready — no wasted LLM turns on setup

### Files (5 files, 224 additions)
- **Node handler** (`workspace.ts`): `workspace.clone` command — Docker exec into container
- **WS client**: `cloneWorkspace()` method with 5-min timeout
- **Dispatcher**: Pre-provision block for `role=development` steps with `issueRepo`
- **Engine**: Passes vars through to dispatcher

Non-fatal — if provisioning fails, agent can still clone manually.

0 TS errors, 163 tests pass.