### PR TITLE
feat: link repos to source control integrations, repo search

### DIFF
--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -52,6 +52,7 @@ import { usageRoutes, internalUsageRouter } from './routes/usage.js';
 import { installScriptRoutes } from './routes/install-script.js';
 import { notificationChannelsRoutes } from './routes/notification-channels.js';
 import workflowArtifactRoutes from './routes/workflow-artifacts.js';
+import projectReposRoutes from './routes/project-repos.js';
 
 export interface AppOptions {
   nodeManager: NodeManager;
@@ -115,6 +116,7 @@ export function createApp(opts: AppOptions): express.Express {
   app.use('/api/projects', projectRoutes);
   app.use('/api/projects/:id/assignments', assignmentRoutes);
   app.use('/api/projects/:id/integrations', createProjectIntegrationRoutes(nodeManager));
+  app.use('/api/projects/:id/repos2', projectReposRoutes);
   app.use('/api/webhooks', webhookRoutes);
   app.use('/api/webhooks/inbound', webhooksInboundMgmtRouter);
   app.use('/api/tools', createToolRoutes(nodeManager));

--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -670,6 +670,21 @@ export const issueDependencies = sqliteTable('issue_dependencies', {
   createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
 
+// ── project_repos (#166) ─────────────────────────────────────────────
+export const projectRepos = sqliteTable('project_repos', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull(),
+  integrationId: text('integration_id').notNull(),
+  fullName: text('full_name').notNull(),
+  defaultBranch: text('default_branch').default('main'),
+  cloneUrl: text('clone_url'),
+  provider: text('provider').notNull(),
+  isPrivate: integer('is_private').notNull().default(0),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+}, (table) => [
+  unique().on(table.projectId, table.fullName),
+]);
+
 // ── notification_channels (#512) ────────────────────────────────────
 export const notificationChannels = sqliteTable('notification_channels', {
   id: text('id').primaryKey(),

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -469,6 +469,68 @@ const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_issue_deps_issue ON issue_dependencies(repo, issue_number)',
     ],
   },
+
+  // ── project_repos (#166) ──────────────────────────────────────────
+  {
+    version: 39,
+    description: 'Create project_repos table for linking repos to source control integrations (#166)',
+    sql: [
+      `CREATE TABLE IF NOT EXISTS project_repos (
+        id              TEXT PRIMARY KEY,
+        project_id      TEXT NOT NULL,
+        integration_id  TEXT NOT NULL,
+        full_name       TEXT NOT NULL,
+        default_branch  TEXT DEFAULT 'main',
+        clone_url       TEXT,
+        provider        TEXT NOT NULL,
+        is_private      INTEGER NOT NULL DEFAULT 0,
+        created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE(project_id, full_name)
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_project_repos_project ON project_repos(project_id)',
+      'CREATE INDEX IF NOT EXISTS idx_project_repos_integration ON project_repos(integration_id)',
+    ],
+  },
+
+  // ── migrate config.repositories → project_repos (#166) ───────────
+  {
+    version: 40,
+    description: 'Migrate existing config.repositories data into project_repos table (#166)',
+    run(db) {
+      const { v4: uuidv4 } = require('uuid');
+      const projects = db.prepare('SELECT id, config_json FROM projects').all() as Array<{ id: string; config_json: string }>;
+
+      for (const project of projects) {
+        let config: any = {};
+        try { config = JSON.parse(project.config_json || '{}'); } catch { continue; }
+        if (!Array.isArray(config.repositories) || config.repositories.length === 0) continue;
+
+        // Find a GitHub integration for this project
+        const piRows = db.prepare(
+          `SELECT pi.id, pi.integration_id, i.provider, i.auth_config
+           FROM project_integrations pi
+           JOIN integrations i ON i.id = pi.integration_id
+           WHERE pi.project_id = ? AND i.provider IN ('github', 'bitbucket', 'gitlab')
+           LIMIT 1`,
+        ).get(project.id) as { id: string; integration_id: string; provider: string; auth_config: string } | undefined;
+
+        if (!piRows) continue;
+
+        for (const repo of config.repositories as Array<{ url: string; defaultBranch?: string }>) {
+          const match = repo.url?.match(/(?:github\.com\/)?([^/]+\/[^/]+?)(?:\.git)?$/);
+          if (!match) continue;
+          const fullName = match[1].replace(/^\//, '');
+          const existing = db.prepare('SELECT id FROM project_repos WHERE project_id = ? AND full_name = ?').get(project.id, fullName);
+          if (existing) continue;
+          const id = uuidv4();
+          db.prepare(
+            `INSERT OR IGNORE INTO project_repos (id, project_id, integration_id, full_name, default_branch, provider, is_private)
+             VALUES (?, ?, ?, ?, ?, ?, 0)`,
+          ).run(id, project.id, piRows.integration_id, fullName, repo.defaultBranch || 'main', piRows.provider);
+        }
+      }
+    },
+  },
 ];
 
 /**

--- a/packages/control/src/repositories/index.ts
+++ b/packages/control/src/repositories/index.ts
@@ -35,3 +35,5 @@ export { notificationChannelRepo } from './notification-channel-repo.js';
 export type { NotificationChannel, NotificationChannelType } from './notification-channel-repo.js';
 export { assignmentRepo, migrateOwnerAssignments } from './assignment-repo.js';
 export type { Assignment, AssignmentType, AssigneeType, ResolvedAssignee } from './assignment-repo.js';
+export { projectReposRepo } from './project-repos-repo.js';
+export type { ProjectRepo } from './project-repos-repo.js';

--- a/packages/control/src/repositories/project-repos-repo.ts
+++ b/packages/control/src/repositories/project-repos-repo.ts
@@ -1,0 +1,93 @@
+import { v4 as uuidv4 } from 'uuid';
+import { eq, and } from 'drizzle-orm';
+import { getDrizzle } from '../db/drizzle.js';
+import { projectRepos } from '../db/drizzle-schema.js';
+
+export interface ProjectRepo {
+  id: string;
+  projectId: string;
+  integrationId: string;
+  fullName: string;
+  defaultBranch: string;
+  cloneUrl: string | null;
+  provider: string;
+  isPrivate: boolean;
+  createdAt: string;
+}
+
+type ProjectRepoRow = typeof projectRepos.$inferSelect;
+
+function rowToProjectRepo(r: ProjectRepoRow): ProjectRepo {
+  return {
+    id: r.id,
+    projectId: r.projectId,
+    integrationId: r.integrationId,
+    fullName: r.fullName,
+    defaultBranch: r.defaultBranch ?? 'main',
+    cloneUrl: r.cloneUrl ?? null,
+    provider: r.provider,
+    isPrivate: r.isPrivate === 1,
+    createdAt: r.createdAt,
+  };
+}
+
+export const projectReposRepo = {
+  getByProject(projectId: string): ProjectRepo[] {
+    return getDrizzle()
+      .select()
+      .from(projectRepos)
+      .where(eq(projectRepos.projectId, projectId))
+      .all()
+      .map(rowToProjectRepo);
+  },
+
+  getByIntegration(integrationId: string): ProjectRepo[] {
+    return getDrizzle()
+      .select()
+      .from(projectRepos)
+      .where(eq(projectRepos.integrationId, integrationId))
+      .all()
+      .map(rowToProjectRepo);
+  },
+
+  getById(id: string): ProjectRepo | null {
+    const row = getDrizzle().select().from(projectRepos).where(eq(projectRepos.id, id)).get();
+    return row ? rowToProjectRepo(row) : null;
+  },
+
+  getByProjectAndName(projectId: string, fullName: string): ProjectRepo | null {
+    const row = getDrizzle()
+      .select()
+      .from(projectRepos)
+      .where(and(eq(projectRepos.projectId, projectId), eq(projectRepos.fullName, fullName)))
+      .get();
+    return row ? rowToProjectRepo(row) : null;
+  },
+
+  add(data: {
+    projectId: string;
+    integrationId: string;
+    fullName: string;
+    defaultBranch?: string;
+    cloneUrl?: string;
+    provider: string;
+    isPrivate?: boolean;
+  }): ProjectRepo {
+    const id = uuidv4();
+    getDrizzle().insert(projectRepos).values({
+      id,
+      projectId: data.projectId,
+      integrationId: data.integrationId,
+      fullName: data.fullName,
+      defaultBranch: data.defaultBranch ?? 'main',
+      cloneUrl: data.cloneUrl ?? null,
+      provider: data.provider,
+      isPrivate: data.isPrivate ? 1 : 0,
+    }).run();
+    return projectReposRepo.getById(id)!;
+  },
+
+  remove(id: string): void {
+    getDrizzle().delete(projectRepos).where(eq(projectRepos.id, id)).run();
+  },
+};

--- a/packages/control/src/routes/project-repos.ts
+++ b/packages/control/src/routes/project-repos.ts
@@ -1,0 +1,238 @@
+// ── Project Repos Routes ─────────────────────────────────────────────
+// Manage linked repositories for projects.
+
+import { Router } from 'express';
+import { requireScope } from '../middleware/scopes.js';
+import { projectsRepo, projectReposRepo } from '../repositories/index.js';
+import { integrationsRepo } from '../services/integrations/integrations-repo.js';
+import { projectIntegrationsRepo } from '../services/integrations/project-integrations-repo.js';
+import { getProvider } from '../services/integrations/registry.js';
+import { registerToolDef } from '../utils/tool-registry.js';
+import { logActivity } from '../services/activity-service.js';
+
+const router = Router({ mergeParams: true });
+
+/* ── Tool definitions ─────────────────────────────────────────────── */
+
+registerToolDef({
+  category: 'projects',
+  name: 'armada_project_repos_list',
+  description: 'List repositories linked to a project (from project_repos table)',
+  method: 'GET',
+  path: '/api/projects/:id/repos2',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID or name', required: true },
+  ],
+  scope: 'projects:read',
+});
+
+registerToolDef({
+  category: 'projects',
+  name: 'armada_project_repos_add',
+  description: 'Link a repository to a project via a source control integration',
+  method: 'POST',
+  path: '/api/projects/:id/repos2',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID or name', required: true },
+    { name: 'integrationId', type: 'string', description: 'Integration ID to use', required: true },
+    { name: 'fullName', type: 'string', description: 'Repository full name (owner/repo)', required: true },
+    { name: 'defaultBranch', type: 'string', description: 'Default branch (default: main)' },
+    { name: 'provider', type: 'string', description: 'Provider: github | bitbucket | gitlab', required: true },
+  ],
+  scope: 'projects:write',
+});
+
+registerToolDef({
+  category: 'projects',
+  name: 'armada_project_repos_remove',
+  description: 'Unlink a repository from a project',
+  method: 'DELETE',
+  path: '/api/projects/:id/repos2/:repoId',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID or name', required: true },
+    { name: 'repoId', type: 'string', description: 'Project repo ID to remove', required: true },
+  ],
+  scope: 'projects:write',
+});
+
+registerToolDef({
+  category: 'projects',
+  name: 'armada_project_repos_search',
+  description: 'Search available repositories via the project\'s source control integrations',
+  method: 'GET',
+  path: '/api/projects/:id/repos2/search',
+  parameters: [
+    { name: 'id', type: 'string', description: 'Project ID or name', required: true },
+    { name: 'q', type: 'string', description: 'Search query to filter repos by name' },
+    { name: 'integrationId', type: 'string', description: 'Specific integration ID to search (optional)' },
+  ],
+  scope: 'projects:read',
+});
+
+/* ── Routes ───────────────────────────────────────────────────────── */
+
+// GET /api/projects/:id/repos2 — list linked repos with integration info
+router.get('/', (req, res) => {
+  const project = projectsRepo.get(((req.params as any).id as string)) || projectsRepo.getByName(((req.params as any).id as string));
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  const repos = projectReposRepo.getByProject(project.id);
+  const enriched = repos.map(r => {
+    const integration = integrationsRepo.getById(r.integrationId);
+    return {
+      ...r,
+      integration: integration
+        ? { id: integration.id, name: integration.name, provider: integration.provider }
+        : null,
+    };
+  });
+  res.json({ repos: enriched });
+});
+
+// GET /api/projects/:id/repos2/search — search available repos via integrations
+router.get('/search', async (req, res) => {
+  const project = projectsRepo.get(((req.params as any).id as string)) || projectsRepo.getByName(((req.params as any).id as string));
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const q = (req.query.q as string || '').toLowerCase();
+  const filterIntegrationId = req.query.integrationId as string | undefined;
+
+  // Get the project's source control integrations
+  const projectIntegrations = projectIntegrationsRepo.getByProject(project.id);
+  const scmProjectIntegrations = projectIntegrations.filter(pi => {
+    if (!pi.enabled) return false;
+    if (filterIntegrationId && pi.integrationId !== filterIntegrationId) return false;
+    const integration = integrationsRepo.getById(pi.integrationId);
+    return integration && ['github', 'bitbucket'].includes(integration.provider);
+  });
+
+  if (scmProjectIntegrations.length === 0) {
+    // Also try all active GitHub integrations if no project-level ones
+    const allIntegrations = integrationsRepo.getAll().filter(i =>
+      ['github', 'bitbucket'].includes(i.provider) &&
+      i.status === 'active' &&
+      (!filterIntegrationId || i.id === filterIntegrationId),
+    );
+    if (allIntegrations.length === 0) {
+      res.json({ repos: [], integrations: [] });
+      return;
+    }
+
+    const allRepos: any[] = [];
+    const usedIntegrations: any[] = [];
+    for (const integration of allIntegrations) {
+      const provider = getProvider(integration.provider);
+      if (!provider?.listRepos) continue;
+      try {
+        const repos = await provider.listRepos(integration.authConfig);
+        const filtered = q ? repos.filter(r => r.fullName.toLowerCase().includes(q)) : repos;
+        allRepos.push(...filtered.map(r => ({ ...r, integrationId: integration.id })));
+        usedIntegrations.push({ id: integration.id, name: integration.name, provider: integration.provider });
+      } catch (err: any) {
+        console.warn(`[project-repos] listRepos failed for integration ${integration.id}:`, err.message);
+      }
+    }
+    res.json({ repos: allRepos, integrations: usedIntegrations });
+    return;
+  }
+
+  const allRepos: any[] = [];
+  const usedIntegrations: any[] = [];
+  for (const pi of scmProjectIntegrations) {
+    const integration = integrationsRepo.getById(pi.integrationId);
+    if (!integration) continue;
+    const provider = getProvider(integration.provider);
+    if (!provider?.listRepos) continue;
+    try {
+      const repos = await provider.listRepos(integration.authConfig);
+      const filtered = q ? repos.filter(r => r.fullName.toLowerCase().includes(q)) : repos;
+      allRepos.push(...filtered.map(r => ({ ...r, integrationId: integration.id })));
+      if (!usedIntegrations.find(i => i.id === integration.id)) {
+        usedIntegrations.push({ id: integration.id, name: integration.name, provider: integration.provider });
+      }
+    } catch (err: any) {
+      console.warn(`[project-repos] listRepos failed for integration ${pi.integrationId}:`, err.message);
+    }
+  }
+
+  res.json({ repos: allRepos, integrations: usedIntegrations });
+});
+
+// POST /api/projects/:id/repos2 — link a repo
+router.post('/', requireScope('projects:write'), (req, res) => {
+  const project = projectsRepo.get(((req.params as any).id as string)) || projectsRepo.getByName(((req.params as any).id as string));
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const { integrationId, fullName, defaultBranch, provider, cloneUrl, isPrivate } = req.body;
+  if (!integrationId || !fullName || !provider) {
+    res.status(400).json({ error: 'integrationId, fullName, and provider are required' });
+    return;
+  }
+
+  const integration = integrationsRepo.getById(integrationId);
+  if (!integration) {
+    res.status(404).json({ error: `Integration not found: ${integrationId}` });
+    return;
+  }
+
+  // Check for duplicate
+  const existing = projectReposRepo.getByProjectAndName(project.id, fullName);
+  if (existing) {
+    res.status(409).json({ error: `Repo ${fullName} is already linked to this project` });
+    return;
+  }
+
+  const repo = projectReposRepo.add({
+    projectId: project.id,
+    integrationId,
+    fullName,
+    defaultBranch: defaultBranch || 'main',
+    cloneUrl: cloneUrl || null,
+    provider,
+    isPrivate: !!isPrivate,
+  });
+
+  logActivity({
+    eventType: 'project.repo.linked',
+    detail: `Repo ${fullName} linked to project "${project.name}" via ${integration.name}`,
+  });
+
+  res.status(201).json(repo);
+});
+
+// DELETE /api/projects/:id/repos2/:repoId — unlink a repo
+router.delete('/:repoId', requireScope('projects:write'), (req, res) => {
+  const project = projectsRepo.get(((req.params as any).id as string)) || projectsRepo.getByName(((req.params as any).id as string));
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const repo = projectReposRepo.getById(((req.params as any).repoId as string));
+  if (!repo) {
+    res.status(404).json({ error: 'Repo not found' });
+    return;
+  }
+  if (repo.projectId !== project.id) {
+    res.status(403).json({ error: 'Repo does not belong to this project' });
+    return;
+  }
+
+  projectReposRepo.remove(((req.params as any).repoId as string));
+  logActivity({
+    eventType: 'project.repo.unlinked',
+    detail: `Repo ${repo.fullName} unlinked from project "${project.name}"`,
+  });
+
+  res.status(204).send();
+});
+
+export default router;

--- a/packages/control/src/routes/proxy-prs.ts
+++ b/packages/control/src/routes/proxy-prs.ts
@@ -7,8 +7,7 @@ import { requireScope } from '../middleware/scopes.js';
 import { getProvider } from '../services/integrations/registry.js';
 import { integrationsRepo } from '../services/integrations/integrations-repo.js';
 import { projectIntegrationsRepo } from '../services/integrations/project-integrations-repo.js';
-import { agentsRepo, templatesRepo } from '../repositories/index.js';
-import { projectsRepo } from '../repositories/index.js';
+import { agentsRepo, templatesRepo, projectsRepo, projectReposRepo } from '../repositories/index.js';
 import { logActivity } from '../services/activity-service.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 import type { IntegrationProvider, PRFilters } from '../services/integrations/types.js';
@@ -42,13 +41,32 @@ function auditLog(agent: string, project: string, action: string, detail?: strin
   });
 }
 
-/** Find the VCS integration for a project and normalise repo list */
+/** Find the VCS integration for a project and normalise repo list.
+ *  Prefers project_repos table; falls back to project_integrations.vcs config for backwards compat. */
 function resolveVcsIntegration(projectId: string): {
   projectIntegration: any;
   integration: any;
   provider: IntegrationProvider;
   repos: string[];
 } | null {
+  // Prefer project_repos table
+  const linkedRepos = projectReposRepo.getByProject(projectId);
+  if (linkedRepos.length > 0) {
+    // Use the first integration found (most recently linked)
+    const firstRepo = linkedRepos[0];
+    const integration = integrationsRepo.getById(firstRepo.integrationId);
+    if (integration && integration.status === 'active') {
+      const provider = getProvider(integration.provider);
+      if (provider) {
+        const repos = linkedRepos
+          .filter(r => r.integrationId === firstRepo.integrationId)
+          .map(r => r.fullName);
+        return { projectIntegration: null, integration, provider, repos };
+      }
+    }
+  }
+
+  // Legacy fallback: project_integrations with capability=vcs
   const pis = projectIntegrationsRepo.getByProject(projectId);
   const vcsPI = pis.find(pi => pi.capability === 'vcs' && pi.enabled);
   if (!vcsPI) return null;

--- a/packages/control/src/services/credential-sync.ts
+++ b/packages/control/src/services/credential-sync.ts
@@ -7,7 +7,7 @@
  *   2. Git credentials → resolved from project integrations, written to git-credentials.json
  */
 
-import { agentsRepo, instancesRepo, projectsRepo } from '../repositories/index.js';
+import { agentsRepo, instancesRepo, projectsRepo, projectReposRepo } from '../repositories/index.js';
 import { projectIntegrationsRepo } from './integrations/project-integrations-repo.js';
 import { integrationsRepo } from './integrations/integrations-repo.js';
 import type { NodeManager } from '../node-manager.js';
@@ -32,54 +32,96 @@ function resolveGitCredentials(agentName: string): GitCredential[] {
   const projects = projectsRepo.getAll();
 
   for (const project of projects) {
-    const projectIntegrations = projectIntegrationsRepo.getByProject(project.id);
+    // Prefer project_repos table for repo-to-integration mapping
+    const linkedRepos = projectReposRepo.getByProject(project.id);
 
-    for (const pi of projectIntegrations) {
-      if (!pi.enabled) continue;
-      const integration = integrationsRepo.getById(pi.integrationId);
-      if (!integration) continue;
-      if (integration.status !== 'active') continue;
+    if (linkedRepos.length > 0) {
+      // Group by integration to build credentials
+      const byIntegration = new Map<string, string[]>();
+      for (const lr of linkedRepos) {
+        const list = byIntegration.get(lr.integrationId) || [];
+        list.push(lr.fullName);
+        byIntegration.set(lr.integrationId, list);
+      }
 
-      const token = integration.authConfig?.token as string | undefined;
-      if (!token || seenTokens.has(token)) continue;
-      seenTokens.add(token);
+      for (const [integrationId, repoNames] of byIntegration) {
+        const integration = integrationsRepo.getById(integrationId);
+        if (!integration || integration.status !== 'active') continue;
 
-      // Determine host and paths based on provider
-      let host = 'github.com';
-      const paths: string[] = [];
+        const token = integration.authConfig?.token as string | undefined;
+        if (!token || seenTokens.has(token)) continue;
+        seenTokens.add(token);
 
-      if (integration.provider === 'github') {
-        host = (integration.authConfig?.url as string)?.replace('https://api.', '').replace('https://', '') || 'github.com';
-        // Scope to repos configured on the project
-        const config = JSON.parse(project.configJson || '{}');
-        const repos: Array<{ url: string }> = config.repositories || [];
-        for (const repo of repos) {
-          const match = repo.url.match(/(?:github\.com\/)?([^/]+\/[^/]+?)(?:\.git)?$/);
-          if (match) {
-            const slug = match[1].replace(/^\//, '');
-            // Add org-level wildcard
-            const org = slug.split('/')[0];
-            if (!paths.includes(`${org}/*`) && !paths.includes('*')) {
+        let host = 'github.com';
+        const paths: string[] = [];
+
+        if (integration.provider === 'github') {
+          host = (integration.authConfig?.url as string)?.replace('https://api.', '').replace('https://', '') || 'github.com';
+          for (const fullName of repoNames) {
+            const org = fullName.split('/')[0];
+            if (org && !paths.includes(`${org}/*`) && !paths.includes('*')) {
               paths.push(`${org}/*`);
             }
           }
+        } else if (integration.provider === 'bitbucket') {
+          host = 'bitbucket.org';
         }
-      } else if (integration.provider === 'bitbucket') {
-        host = 'bitbucket.org';
-      }
 
-      // If no specific paths, allow all (wildcard)
-      if (paths.length === 0) {
-        paths.push('*');
-      }
+        if (paths.length === 0) paths.push('*');
 
-      credentials.push({
-        host,
-        protocol: 'https',
-        username: 'x-access-token',
-        password: token,
-        paths,
-      });
+        credentials.push({
+          host,
+          protocol: 'https',
+          username: 'x-access-token',
+          password: token,
+          paths,
+        });
+      }
+    } else {
+      // Legacy fallback: read from project_integrations + config.repositories
+      const projectIntegrations = projectIntegrationsRepo.getByProject(project.id);
+
+      for (const pi of projectIntegrations) {
+        if (!pi.enabled) continue;
+        const integration = integrationsRepo.getById(pi.integrationId);
+        if (!integration) continue;
+        if (integration.status !== 'active') continue;
+
+        const token = integration.authConfig?.token as string | undefined;
+        if (!token || seenTokens.has(token)) continue;
+        seenTokens.add(token);
+
+        let host = 'github.com';
+        const paths: string[] = [];
+
+        if (integration.provider === 'github') {
+          host = (integration.authConfig?.url as string)?.replace('https://api.', '').replace('https://', '') || 'github.com';
+          const config = JSON.parse(project.configJson || '{}');
+          const repos: Array<{ url: string }> = config.repositories || [];
+          for (const repo of repos) {
+            const match = repo.url.match(/(?:github\.com\/)?([^/]+\/[^/]+?)(?:\.git)?$/);
+            if (match) {
+              const slug = match[1].replace(/^\//, '');
+              const org = slug.split('/')[0];
+              if (!paths.includes(`${org}/*`) && !paths.includes('*')) {
+                paths.push(`${org}/*`);
+              }
+            }
+          }
+        } else if (integration.provider === 'bitbucket') {
+          host = 'bitbucket.org';
+        }
+
+        if (paths.length === 0) paths.push('*');
+
+        credentials.push({
+          host,
+          protocol: 'https',
+          username: 'x-access-token',
+          password: token,
+          paths,
+        });
+      }
     }
   }
 

--- a/packages/control/src/services/issue-sync.ts
+++ b/packages/control/src/services/issue-sync.ts
@@ -1,4 +1,4 @@
-import { projectsRepo, settingsRepo } from '../repositories/index.js';
+import { projectsRepo, settingsRepo, projectReposRepo } from '../repositories/index.js';
 import { getDrizzle } from '../db/drizzle.js';
 import { githubIssueCache, triagedIssues, issueDependencies } from '../db/drizzle-schema.js';
 import { eq, sql, and } from 'drizzle-orm';
@@ -111,17 +111,44 @@ export async function syncProjectIssues(projectId: string): Promise<{ fetched: n
   const project = projectsRepo.get(projectId);
   if (!project) throw new Error('Project not found');
 
+  // Prefer project_repos table; fall back to config.repositories for backwards compat
+  const linkedRepos = projectReposRepo.getByProject(projectId);
   const config = JSON.parse(project.configJson || '{}');
-  const repos: Array<{ url: string }> = config.repositories || [];
-  const token = resolveGitHubToken(projectId);
+  const legacyRepos: Array<{ url: string }> = config.repositories || [];
+
+  // Build list of {slug, token} pairs to fetch
+  type RepoFetch = { slug: string; token: string };
+  const repoFetches: RepoFetch[] = [];
+
+  if (linkedRepos.length > 0) {
+    for (const lr of linkedRepos) {
+      if (lr.provider !== 'github') continue;
+      let token = '';
+      try {
+        const integration = (await import('./integrations/integrations-repo.js')).integrationsRepo.getById(lr.integrationId);
+        if (integration?.authConfig?.token) {
+          token = integration.authConfig.token as string;
+        }
+      } catch {}
+      if (!token) token = resolveGitHubToken(projectId);
+      repoFetches.push({ slug: lr.fullName, token });
+    }
+  } else {
+    // Legacy fallback: config.repositories + global token
+    const token = resolveGitHubToken(projectId);
+    for (const repo of legacyRepos) {
+      const match = repo.url.match(/(?:github\.com\/)?([^/]+\/[^/]+?)(?:\.git)?$/);
+      if (!match) continue;
+      const slug = match[1].replace(/^\//, '');
+      const parts = slug.split('/');
+      if (parts.length < 2) continue;
+      repoFetches.push({ slug, token });
+    }
+  }
 
   const allIssues: GitHubIssue[] = [];
 
-  for (const repo of repos) {
-    // Parse owner/repo from url
-    const match = repo.url.match(/(?:github\.com\/)?([^/]+\/[^/]+?)(?:\.git)?$/);
-    if (!match) continue;
-    const slug = match[1].replace(/^\//, '');
+  for (const { slug, token: repoToken } of repoFetches) {
     const parts = slug.split('/');
     if (parts.length < 2) continue;
     const owner = parts[0];
@@ -133,7 +160,7 @@ export async function syncProjectIssues(projectId: string): Promise<{ fetched: n
       `${GITHUB_API}/repos/${owner}/${repoName}/issues?state=open&per_page=100&sort=updated`,
       {
         headers: {
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(repoToken ? { Authorization: `Bearer ${repoToken}` } : {}),
           Accept: 'application/vnd.github.v3+json',
         },
         signal: AbortSignal.timeout(30_000),
@@ -266,7 +293,8 @@ export function startIssueSyncScheduler() {
 
     for (const project of projects) {
       const config = JSON.parse(project.configJson || '{}');
-      if ((config.repositories || []).length === 0) continue;
+      const linkedReposCount = projectReposRepo.getByProject(project.id).length;
+      if (linkedReposCount === 0 && (config.repositories || []).length === 0) continue;
 
       // Resolve per-project interval
       const intervalMs = resolveProjectIntervalMs(config);


### PR DESCRIPTION
Closes #166

### Changes (9 files, 555 additions)

**New table**: `project_repos` — links repos to projects via integrations
- Migration v39: create table with unique constraint
- Migration v40: auto-migrate existing `config.repositories` data

**New repo**: `projectReposRepo` — CRUD for project repos

**New routes** (`/api/projects/:id/repos2`):
- List, add, remove repos
- Search available repos via project's integration API
- 4 new tools: `armada_project_repos_list/add/remove/search`

**Updated services**:
- `issue-sync.ts` — prefers `project_repos` table for per-repo tokens
- `credential-sync.ts` — reads from `project_repos` → integration → token
- `proxy-prs.ts` — resolves VCS integration via `project_repos` table

All with backwards-compatible fallback to legacy `config.repositories`.

0 TS errors, 163 tests pass.