### PR TITLE
feat: armada.json + auto-discovery + build verification before PR creation

### DIFF
--- a/packages/control/src/infrastructure/ws-node-client.ts
+++ b/packages/control/src/infrastructure/ws-node-client.ts
@@ -7,7 +7,7 @@
  */
 
 import { commandDispatcher } from '../ws/command-dispatcher.js';
-import type { ProgressMessage } from '@coderage-labs/armada-shared';
+import type { ProgressMessage, RepoDiscovery } from '@coderage-labs/armada-shared';
 
 export class WsNodeClient {
   constructor(public readonly nodeId: string) {}
@@ -404,6 +404,39 @@ export class WsNodeClient {
       branch: string;
       status: string;
     }>;
+  }
+
+  /**
+   * Execute a shell command inside an instance container at a given working directory.
+   * Returns exit code and combined stdout/stderr output.
+   *
+   * @param instanceName  Instance name (without the armada-instance- prefix)
+   * @param path          Working directory inside the container
+   * @param cmd           Shell command string to execute (run via sh -c)
+   */
+  async execInWorkspace(
+    instanceName: string,
+    path: string,
+    cmd: string,
+    timeoutMs = 120_000,
+  ): Promise<{ exitCode: number; output: string }> {
+    const containerName = `armada-instance-${instanceName}`;
+    return this.send('workspace.exec', { instanceId: containerName, path, cmd }, timeoutMs) as Promise<{
+      exitCode: number;
+      output: string;
+    }>;
+  }
+
+  /**
+   * Discover workspace stacks and armada.json config inside a container.
+   * Walks up to 2 levels deep detecting Node, Go, Python, Rust, Terraform, Java, etc.
+   *
+   * @param instanceName  Instance name (without the armada-instance- prefix)
+   * @param path          Absolute path inside the container to discover from
+   */
+  async discoverWorkspace(instanceName: string, path: string): Promise<RepoDiscovery> {
+    const containerName = `armada-instance-${instanceName}`;
+    return this.send('workspace.discover', { instanceId: containerName, path }, 30_000) as Promise<RepoDiscovery>;
   }
 
   // === Instance event relay ===

--- a/packages/control/src/routes/proxy-prs.ts
+++ b/packages/control/src/routes/proxy-prs.ts
@@ -7,10 +7,11 @@ import { requireScope } from '../middleware/scopes.js';
 import { getProvider } from '../services/integrations/registry.js';
 import { integrationsRepo } from '../services/integrations/integrations-repo.js';
 import { projectIntegrationsRepo } from '../services/integrations/project-integrations-repo.js';
-import { agentsRepo, templatesRepo, projectsRepo, projectReposRepo } from '../repositories/index.js';
+import { agentsRepo, templatesRepo, projectsRepo, projectReposRepo, instancesRepo } from '../repositories/index.js';
 import { logActivity } from '../services/activity-service.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 import type { IntegrationProvider, PRFilters } from '../services/integrations/types.js';
+import { getNodeClient } from '../infrastructure/node-client.js';
 
 const router = Router();
 
@@ -337,7 +338,7 @@ router.post('/comment', requireScope('prs:write'), async (req, res, next) => {
 registerToolDef({
   category: 'issues',
   name: 'armada_pr_create',
-  description: 'Create a pull request',
+  description: 'Create a pull request. If workspacePath is provided, runs the verify command from armada.json (or auto-detected build config) before creating the PR — the PR is only created if verification passes.',
   method: 'POST',
   path: '/api/proxy/prs/create',
   parameters: [
@@ -349,6 +350,7 @@ registerToolDef({
     { name: 'base', type: 'string', description: 'Target branch (defaults to repo default branch)' },
     { name: 'draft', type: 'boolean', description: 'Create as draft PR (default: false)' },
     { name: 'labels', type: 'string', description: 'JSON array of label names' },
+    { name: 'workspacePath', type: 'string', description: 'Absolute path in the calling agent\'s container to run build verification from (reads armada.json or auto-detects). PR is blocked if verify fails.' },
   ],
     scope: 'prs:write',
 });
@@ -356,7 +358,7 @@ registerToolDef({
 router.post('/create', requireScope('prs:write'), async (req, res, next) => {
   try {
     const agentName = (req.caller as any)?.agentName ?? null;
-    const { project: projectRef, repo, title, body, head, base, draft, labels } = req.body;
+    const { project: projectRef, repo, title, body, head, base, draft, labels, workspacePath } = req.body;
     if (!projectRef || !repo || !title || !body || !head) return res.status(400).json({ error: 'project, repo, title, body, and head are required' });
 
     const project = resolveProject(projectRef);
@@ -369,6 +371,53 @@ router.post('/create', requireScope('prs:write'), async (req, res, next) => {
     const { integration, provider, repos: configRepos } = resolved;
     if (!provider.createPR) return res.status(501).json({ error: `Provider ${integration.provider} does not support createPR` });
     if (!validateRepo(configRepos, repo)) return res.status(403).json({ error: `Repo ${repo} is not configured for project ${project.name}` });
+
+    // ── Build verification (optional) ────────────────────────────────
+    // When workspacePath is provided, discover the build config and run
+    // the verify command inside the calling agent's container. PR creation
+    // is blocked if verification fails.
+    if (workspacePath && agentName) {
+      try {
+        // Resolve the calling agent's instance to find its node
+        const agents = agentsRepo.getAll();
+        const callerAgent = agents.find(a => a.name === agentName);
+        const instanceId = callerAgent?.instanceId;
+        const instance = instanceId ? instancesRepo.getById(instanceId) : null;
+
+        if (instance?.nodeId) {
+          const nodeClient = getNodeClient(instance.nodeId);
+          const discovery = await nodeClient.discoverWorkspace(instance.name, workspacePath);
+
+          // Prefer rootConfig verify; fall back to first detected stack's verify
+          const verifyCmd = discovery.rootConfig?.verify
+            ?? discovery.detected.find(d => d.buildConfig.verify)?.buildConfig.verify;
+
+          if (verifyCmd) {
+            console.log(`[proxy-prs] Running build verification for ${agentName}: ${verifyCmd}`);
+
+            // Execute the verify command in the container via workspace.exec
+            const verifyResult = await nodeClient.execInWorkspace(instance.name, workspacePath, verifyCmd, 120_000);
+
+            if (verifyResult.exitCode !== 0) {
+              auditLog(agentName, project.name, 'create-blocked', `${repo} — verify failed`);
+              return res.status(422).json({
+                error: 'Build verification failed — PR not created',
+                verifyCmd,
+                output: verifyResult.output,
+                exitCode: verifyResult.exitCode,
+              });
+            }
+
+            console.log(`[proxy-prs] Build verification passed for ${agentName}`);
+          }
+        } else {
+          console.warn(`[proxy-prs] workspacePath provided but could not resolve instance for agent ${agentName} — skipping verification`);
+        }
+      } catch (verifyErr: any) {
+        // Log but don't block PR creation if verification infrastructure fails
+        console.warn(`[proxy-prs] Build verification error (non-blocking): ${verifyErr.message}`);
+      }
+    }
 
     // Parse labels — accept both JSON array and string array
     let parsedLabels: string[] | undefined;

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -139,6 +139,7 @@ export function initWorkflowDispatcher() {
       // For development steps with an issueRepo, clone the repo into the
       // instance container before sending the task so the agent can start
       // work immediately without needing to clone manually.
+      let discoveryContext = '';
       if (opts.role === 'development' && opts.vars?.issueRepo) {
         const issueRepo = opts.vars.issueRepo as string;
         const issueNumber = opts.vars.issueNumber as number | undefined;
@@ -149,11 +150,46 @@ export function initWorkflowDispatcher() {
           : 'impl';
         const branch = `feature/${issueNumber ? `${issueNumber}-` : ''}${slugTitle}`;
         const workPath = `/tmp/work/${repoName}`;
-
         try {
           const wsNode = getNodeClient(instance.nodeId);
           await wsNode.cloneWorkspace(instance.name, issueRepo, branch, workPath);
           console.log(`[workflow-dispatcher] Provisioned workspace for step "${opts.stepId}": ${workPath} (branch: ${branch})`);
+
+          // Run workspace discovery after clone to inject stack info into the task prompt
+          try {
+            const discovery = await wsNode.discoverWorkspace(instance.name, workPath);
+            const lines: string[] = [];
+
+            if (discovery.rootConfig) {
+              lines.push('[WORKSPACE CONFIG]');
+              const cfg = discovery.rootConfig;
+              if (cfg.install) lines.push(`Install: ${cfg.install}`);
+              if (cfg.verify) lines.push(`Verify: ${cfg.verify}`);
+              if (cfg.test) lines.push(`Test: ${cfg.test}`);
+              if (cfg.context) lines.push(`Context: ${cfg.context}`);
+              if (cfg.conventions) lines.push(`Conventions: ${cfg.conventions}`);
+              lines.push('[END WORKSPACE CONFIG]');
+            }
+
+            if (discovery.detected.length > 0) {
+              lines.push('[DETECTED STACKS]');
+              for (const pkg of discovery.detected) {
+                const cfgParts: string[] = [];
+                if (pkg.buildConfig.verify) cfgParts.push(`verify: ${pkg.buildConfig.verify}`);
+                if (pkg.buildConfig.test) cfgParts.push(`test: ${pkg.buildConfig.test}`);
+                lines.push(`- ${pkg.path} (${pkg.stack})${cfgParts.length ? ': ' + cfgParts.join(', ') : ''}`);
+              }
+              lines.push('[END DETECTED STACKS]');
+            }
+
+            if (lines.length > 0) {
+              discoveryContext = '\n\n' + lines.join('\n');
+              console.log(`[workflow-dispatcher] Discovery context injected for step "${opts.stepId}"`);
+            }
+          } catch (discErr: any) {
+            // Non-fatal — discovery is best-effort
+            console.warn(`[workflow-dispatcher] Workspace discovery failed for step "${opts.stepId}": ${discErr.message}`);
+          }
         } catch (err: any) {
           // Non-fatal — the agent can still clone manually
           console.warn(`[workflow-dispatcher] Workspace provisioning failed for step "${opts.stepId}": ${err.message}`);
@@ -166,7 +202,7 @@ export function initWorkflowDispatcher() {
         taskId: opts.taskId,
         from: 'workflow-engine',
         fromRole: 'operator',
-        message: opts.message + worktreeContext,
+        message: opts.message + worktreeContext + (discoveryContext ?? ''),
         callbackUrl: `${callbackBaseUrl}/api/tasks/${opts.taskId}/result`,
         projectId: opts.projectId,
         ...(agent.targetAgent && { targetAgent: agent.targetAgent }),

--- a/packages/node/src/handlers/workspace-discovery.ts
+++ b/packages/node/src/handlers/workspace-discovery.ts
@@ -1,0 +1,233 @@
+/**
+ * Workspace discovery — auto-detects project stacks and reads armada.json config.
+ *
+ * Runs inside a container by executing shell commands via containerExec.
+ * Returns a RepoDiscovery with optional rootConfig (from armada.json) and
+ * a list of detected packages.
+ */
+
+import type { BuildConfig, DetectedPackage, RepoDiscovery } from '@coderage-labs/armada-shared';
+
+/** Run a shell command inside a container and return stdout + stderr as a string. */
+type ContainerExecFn = (cmd: string[]) => Promise<{ exitCode: number; output: string }>;
+
+/** Parse armada.json content into a BuildConfig. Returns undefined if invalid. */
+function parseArmadaJson(content: string): BuildConfig | undefined {
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const cfg: BuildConfig = {};
+    if (typeof parsed.install === 'string') cfg.install = parsed.install;
+    if (typeof parsed.verify === 'string') cfg.verify = parsed.verify;
+    if (typeof parsed.test === 'string') cfg.test = parsed.test;
+    if (typeof parsed.context === 'string') cfg.context = parsed.context;
+    if (typeof parsed.conventions === 'string') cfg.conventions = parsed.conventions;
+    return cfg;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Infer BuildConfig for a Node.js project from its package.json. */
+function inferNodeBuildConfig(packageJsonContent: string): BuildConfig {
+  const cfg: BuildConfig = { install: 'npm install' };
+  try {
+    const pkg = JSON.parse(packageJsonContent);
+    const devDeps = { ...pkg.devDependencies, ...pkg.dependencies };
+    if (devDeps?.typescript) {
+      cfg.verify = 'npx tsc --noEmit';
+    }
+    if (pkg.scripts?.test) {
+      cfg.test = 'npm test';
+    }
+  } catch {
+    // Use defaults
+  }
+  return cfg;
+}
+
+/** Infer BuildConfig for a known stack. */
+function inferBuildConfig(stack: string, extraContent?: string): BuildConfig {
+  switch (stack) {
+    case 'node':
+      return inferNodeBuildConfig(extraContent || '{}');
+    case 'go':
+      return { install: 'go mod download', verify: 'go build ./...', test: 'go test ./...' };
+    case 'python':
+      return { install: 'pip install -r requirements.txt', verify: 'python -m py_compile', test: 'pytest' };
+    case 'rust':
+      return { install: 'cargo fetch', verify: 'cargo check', test: 'cargo test' };
+    case 'terraform':
+      return { install: 'terraform init', verify: 'terraform validate', test: 'terraform plan' };
+    case 'java-maven':
+      return { install: 'mvn dependency:resolve', verify: 'mvn compile -q', test: 'mvn test' };
+    case 'java-gradle':
+      return { install: 'gradle dependencies', verify: 'gradle compileJava', test: 'gradle test' };
+    case 'docker':
+      return { verify: 'docker build --no-cache .' };
+    default:
+      return {};
+  }
+}
+
+/** List files in a directory inside the container. Returns [] on failure. */
+async function listDir(exec: ContainerExecFn, dirPath: string): Promise<string[]> {
+  const result = await exec(['sh', '-c', `ls -1 "${dirPath}" 2>/dev/null || true`]);
+  if (!result.output.trim()) return [];
+  return result.output.split('\n').map(l => l.trim()).filter(Boolean);
+}
+
+/** Check if a file exists in the container. */
+async function fileExists(exec: ContainerExecFn, filePath: string): Promise<boolean> {
+  const result = await exec(['sh', '-c', `test -f "${filePath}" && echo "yes" || echo "no"`]);
+  return result.output.trim() === 'yes';
+}
+
+/** Read file contents from container. Returns undefined on failure. */
+async function readFile(exec: ContainerExecFn, filePath: string): Promise<string | undefined> {
+  const result = await exec(['sh', '-c', `cat "${filePath}" 2>/dev/null`]);
+  if (result.exitCode !== 0) return undefined;
+  return result.output;
+}
+
+/** Check if any .tf files exist in a directory. */
+async function hasTfFiles(exec: ContainerExecFn, dirPath: string): Promise<boolean> {
+  const result = await exec(['sh', '-c', `ls "${dirPath}"/*.tf 2>/dev/null | head -1`]);
+  return result.output.trim().length > 0;
+}
+
+/** Detect the stack at a given directory path. Returns null if nothing detected. */
+async function detectStackAtPath(
+  exec: ContainerExecFn,
+  dirPath: string,
+): Promise<{ stack: string; extraContent?: string } | null> {
+  // Check package.json
+  const pkgJsonPath = `${dirPath}/package.json`;
+  if (await fileExists(exec, pkgJsonPath)) {
+    const content = await readFile(exec, pkgJsonPath);
+    return { stack: 'node', extraContent: content };
+  }
+
+  // Check go.mod
+  if (await fileExists(exec, `${dirPath}/go.mod`)) {
+    return { stack: 'go' };
+  }
+
+  // Check Python
+  if (await fileExists(exec, `${dirPath}/requirements.txt`) || await fileExists(exec, `${dirPath}/pyproject.toml`)) {
+    return { stack: 'python' };
+  }
+
+  // Check Rust
+  if (await fileExists(exec, `${dirPath}/Cargo.toml`)) {
+    return { stack: 'rust' };
+  }
+
+  // Check Java/Maven
+  if (await fileExists(exec, `${dirPath}/pom.xml`)) {
+    return { stack: 'java-maven' };
+  }
+
+  // Check Gradle
+  if (await fileExists(exec, `${dirPath}/build.gradle`)) {
+    return { stack: 'java-gradle' };
+  }
+
+  // Check Dockerfile
+  if (await fileExists(exec, `${dirPath}/Dockerfile`)) {
+    return { stack: 'docker' };
+  }
+
+  // Check Terraform (.tf files)
+  if (await hasTfFiles(exec, dirPath)) {
+    return { stack: 'terraform' };
+  }
+
+  return null;
+}
+
+/**
+ * Discover workspace configuration and stacks at a given path inside a container.
+ *
+ * @param exec  A function that executes shell commands inside the container
+ * @param rootPath  Absolute path in the container to start discovery from
+ * @returns RepoDiscovery with optional rootConfig and detected packages
+ */
+export async function discoverWorkspace(
+  exec: ContainerExecFn,
+  rootPath: string,
+): Promise<RepoDiscovery> {
+  const result: RepoDiscovery = { detected: [] };
+
+  // 1. Check for armada.json at root
+  const armadaJsonPath = `${rootPath}/armada.json`;
+  const armadaJsonContent = await readFile(exec, armadaJsonPath);
+  if (armadaJsonContent) {
+    const parsed = parseArmadaJson(armadaJsonContent);
+    if (parsed) {
+      result.rootConfig = parsed;
+    }
+  }
+
+  // 2. Walk up to 2 levels deep looking for stack markers
+  const detected: DetectedPackage[] = [];
+
+  // Check root itself
+  const rootStack = await detectStackAtPath(exec, rootPath);
+  if (rootStack) {
+    detected.push({
+      path: '.',
+      stack: rootStack.stack,
+      buildConfig: inferBuildConfig(rootStack.stack, rootStack.extraContent),
+    });
+  }
+
+  // Check level 1 subdirectories
+  const level1Dirs = await listDir(exec, rootPath);
+  for (const entry of level1Dirs) {
+    // Skip hidden dirs and common non-project dirs
+    if (entry.startsWith('.') || entry === 'node_modules' || entry === 'dist' || entry === 'build' || entry === 'target' || entry === '.git') {
+      continue;
+    }
+    const level1Path = `${rootPath}/${entry}`;
+    // Only descend into directories
+    const isDirResult = await exec(['sh', '-c', `test -d "${level1Path}" && echo "yes" || echo "no"`]);
+    if (isDirResult.output.trim() !== 'yes') continue;
+
+    const l1Stack = await detectStackAtPath(exec, level1Path);
+    if (l1Stack) {
+      // Only add if it wasn't already counted at root (path '.' covers the root)
+      detected.push({
+        path: entry,
+        stack: l1Stack.stack,
+        buildConfig: inferBuildConfig(l1Stack.stack, l1Stack.extraContent),
+      });
+
+      // Don't descend further into a detected stack dir (avoid noisy sub-packages)
+      continue;
+    }
+
+    // Check level 2 subdirectories
+    const level2Dirs = await listDir(exec, level1Path);
+    for (const subEntry of level2Dirs) {
+      if (subEntry.startsWith('.') || subEntry === 'node_modules' || subEntry === 'dist' || subEntry === 'build' || subEntry === 'target' || subEntry === '.git') {
+        continue;
+      }
+      const level2Path = `${level1Path}/${subEntry}`;
+      const isDirResult2 = await exec(['sh', '-c', `test -d "${level2Path}" && echo "yes" || echo "no"`]);
+      if (isDirResult2.output.trim() !== 'yes') continue;
+
+      const l2Stack = await detectStackAtPath(exec, level2Path);
+      if (l2Stack) {
+        detected.push({
+          path: `${entry}/${subEntry}`,
+          stack: l2Stack.stack,
+          buildConfig: inferBuildConfig(l2Stack.stack, l2Stack.extraContent),
+        });
+      }
+    }
+  }
+
+  result.detected = detected;
+  return result;
+}

--- a/packages/node/src/handlers/workspace.ts
+++ b/packages/node/src/handlers/workspace.ts
@@ -10,6 +10,7 @@
 import Docker from 'dockerode';
 import type { CommandMessage, ResponseMessage } from '@coderage-labs/armada-shared';
 import { WsErrorCode } from '@coderage-labs/armada-shared';
+import { discoverWorkspace } from './workspace-discovery.js';
 
 const docker = new Docker({ socketPath: '/var/run/docker.sock' });
 
@@ -153,10 +154,99 @@ export async function handleWorkspaceClone(msg: CommandMessage): Promise<Respons
   }
 }
 
+export async function handleWorkspaceExec(msg: CommandMessage): Promise<ResponseMessage> {
+  const params = msg.params as {
+    instanceId: string;
+    path: string;
+    cmd: string;
+  };
+
+  const { instanceId, path: workPath, cmd } = params;
+  if (!instanceId || !workPath || !cmd) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: 'instanceId, path, and cmd are required',
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+
+  console.log(`[workspace] Exec in ${instanceId}:${workPath}: ${cmd}`);
+
+  try {
+    const result = await containerExec(instanceId, [
+      'sh', '-c', `cd "${workPath}" && ${cmd}`,
+    ]);
+
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { exitCode: result.exitCode, output: result.output },
+    };
+  } catch (err: any) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: `Workspace exec failed: ${err.message}`,
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+}
+
+export async function handleWorkspaceDiscover(msg: CommandMessage): Promise<ResponseMessage> {
+  const params = msg.params as {
+    instanceId: string;
+    path: string;
+  };
+
+  const { instanceId, path: workPath } = params;
+  if (!instanceId || !workPath) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: 'instanceId and path are required',
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+
+  console.log(`[workspace] Discovering workspace in ${instanceId}:${workPath}`);
+
+  try {
+    // Create an exec function bound to this container
+    const exec = (cmd: string[]) => containerExec(instanceId, cmd);
+    const discovery = await discoverWorkspace(exec, workPath);
+
+    console.log(`[workspace] Discovery complete: rootConfig=${!!discovery.rootConfig}, detected=${discovery.detected.length} packages`);
+
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: discovery,
+    };
+  } catch (err: any) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: `Workspace discovery failed: ${err.message}`,
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+}
+
 export async function handleWorkspaceCommand(msg: CommandMessage): Promise<ResponseMessage> {
   switch (msg.action) {
     case 'workspace.clone':
       return handleWorkspaceClone(msg);
+    case 'workspace.discover':
+      return handleWorkspaceDiscover(msg);
+    case 'workspace.exec':
+      return handleWorkspaceExec(msg);
     default:
       return {
         type: 'response',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -800,6 +800,27 @@ export interface Changeset {
   requiresRestart?: boolean;
 }
 
+// ── Workspace Discovery (#172) ──────────────────────────────────────
+
+export interface BuildConfig {
+  install?: string;
+  verify?: string;
+  test?: string;
+  context?: string;
+  conventions?: string;
+}
+
+export interface DetectedPackage {
+  path: string;       // Relative path in repo
+  stack: string;      // 'node' | 'go' | 'python' | 'rust' | 'terraform' | 'java-maven' | 'java-gradle' | 'docker'
+  buildConfig: BuildConfig;  // Inferred commands
+}
+
+export interface RepoDiscovery {
+  rootConfig?: BuildConfig;   // From armada.json at root
+  detected: DetectedPackage[]; // Auto-detected packages
+}
+
 // ── Changeset Conflict Resolution (#320) ───────────────────────────
 
 export interface ConflictCheck {


### PR DESCRIPTION
Closes #172

### What it does

1. **Auto-discovery**: After workspace clone, scans repo for stack markers (package.json, go.mod, requirements.txt, Cargo.toml, *.tf, etc.) and infers build/verify/test commands
2. **armada.json**: If present at repo root, overrides auto-detected config
3. **Build verification**: `armada_pr_create` runs the verify command before creating a PR — returns 422 if it fails
4. **Context injection**: Discovered stack info and armada.json context/conventions injected into agent prompt

### Files (6 files, 468 additions)
- Node: workspace-discovery.ts (auto-detect), workspace.ts (discover + exec commands)
- Control: ws-node-client (discover + exec methods), dispatcher (discovery after clone, prompt injection), proxy-prs (verify gate on PR creation)
- Shared: BuildConfig, DetectedPackage, RepoDiscovery types

0 TS errors, 163 tests pass.