### PR TITLE
feat: git worktrees per workflow step with lifecycle cleanup

### DIFF
--- a/packages/control/src/infrastructure/ws-node-client.ts
+++ b/packages/control/src/infrastructure/ws-node-client.ts
@@ -428,6 +428,49 @@ export class WsNodeClient {
   }
 
   /**
+   * Provision a git worktree for a workflow step inside an instance container.
+   * Uses a persistent base repo at /data/repos/{org}/{repoName} (clones once, fetches on reuse).
+   * Creates an isolated worktree at /data/worktrees/{runId[0:8]}/{stepId}.
+   * Automatically runs `npm ci` or armada.json install after checkout.
+   *
+   * @param instanceName  Instance name (without the armada-instance- prefix)
+   * @param opts.repo     GitHub repo in "owner/repo" format or full https/git URL
+   * @param opts.branch   Branch name to create in the worktree
+   * @param opts.stepId   Step ID (used as the worktree subdirectory name)
+   * @param opts.runId    Run ID (first 8 chars used as the run directory name)
+   * @param opts.installCmd  Optional custom install command (overrides auto-detection)
+   */
+  async provisionWorkspace(
+    instanceName: string,
+    opts: {
+      repo: string;
+      branch: string;
+      stepId: string;
+      runId: string;
+      installCmd?: string;
+    },
+  ): Promise<{ path: string; branch: string; status: string }> {
+    const containerName = `armada-instance-${instanceName}`;
+    return this.send('workspace.provision', { instanceId: containerName, ...opts }, 300_000) as Promise<{
+      path: string;
+      branch: string;
+      status: string;
+    }>;
+  }
+
+  /**
+   * Clean up all worktrees created for a workflow run.
+   * Removes all worktrees under /data/worktrees/{runId[0:8]}/ inside the container.
+   *
+   * @param instanceName  Instance name (without the armada-instance- prefix)
+   * @param runId         Run ID (first 8 chars used to locate worktrees)
+   */
+  async cleanupWorkspaces(instanceName: string, runId: string): Promise<{ cleaned: number }> {
+    const containerName = `armada-instance-${instanceName}`;
+    return this.send('workspace.cleanup', { instanceId: containerName, runId }, 60_000) as Promise<{ cleaned: number }>;
+  }
+
+  /**
    * Discover workspace stacks and armada.json config inside a container.
    * Walks up to 2 levels deep detecting Node, Go, Python, Rust, Terraform, Java, etc.
    *

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -6,7 +6,7 @@
 
 import { agentsRepo, instancesRepo, projectsRepo } from '../repositories/index.js';
 import { tasksRepo } from '../repositories/index.js';
-import { setWorkflowDispatcher, setWorkflowNotifier, onStepCompleted } from './workflow-engine.js';
+import { setWorkflowDispatcher, setWorkflowNotifier, setWorkspaceCleanupFn, onStepCompleted } from './workflow-engine.js';
 import { getAgentsByRoleWithCapacity } from './health-monitor.js';
 import { notifyGate, notifyCompletion } from './user-notifier.js';
 import { getNodeClient } from '../infrastructure/node-client.js';
@@ -151,12 +151,18 @@ export function initWorkflowDispatcher() {
           ? issueTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 30).replace(/-+$/, '')
           : 'impl';
         const branch = `feature/${issueNumber ? `${issueNumber}-` : ''}${slugTitle}`;
-        // Use step-specific path to avoid collisions in multi-repo workflows
-        const workPath = `/tmp/work/${opts.stepId}/${repoName}`;
+        let workPath: string | undefined;
         try {
           const wsNode = getNodeClient(instance.nodeId);
-          await wsNode.cloneWorkspace(instance.name, targetRepo, branch, workPath);
-          console.log(`[workflow-dispatcher] Provisioned workspace for step "${opts.stepId}": ${workPath} (branch: ${branch})`);
+          const provisionResult = await wsNode.provisionWorkspace(instance.name, {
+            repo: targetRepo,
+            branch,
+            stepId: opts.stepId,
+            runId: opts.runId,
+            installCmd: undefined, // Let the node discover from armada.json
+          });
+          workPath = provisionResult.path;
+          console.log(`[workflow-dispatcher] Provisioned worktree for step "${opts.stepId}": ${workPath} (branch: ${branch})`);
 
           // Run workspace discovery after clone to inject stack info into the task prompt
           try {
@@ -274,6 +280,11 @@ export function initWorkflowDispatcher() {
     }
   });
 
+  // ── Register workspace cleanup hook ──────────────────────────────────
+  setWorkspaceCleanupFn(async (run) => {
+    await cleanupWorkspacesForRun(run.id);
+  });
+
   console.log('🔄 Workflow dispatcher initialized');
 }
 
@@ -318,6 +329,54 @@ async function _cleanupWorktreeForTask(taskId: string): Promise<void> {
   }
   // cleanupWorktree already removes from _activeWorktrees; remove from local map too
   _worktreeTasks.delete(taskId);
+}
+
+/**
+ * Clean up all workspace worktrees provisioned for a workflow run.
+ * Finds the agent/instance that ran this run's steps and calls cleanupWorkspaces.
+ */
+async function cleanupWorkspacesForRun(runId: string): Promise<void> {
+  // Find steps that were run with a task in this run (any step run with an agent assigned)
+  // We need the instance name — look up from any agent that ran steps in this run
+  const stepRunsWithAgents = Array.from(_worktreeTasks.entries())
+    .filter(([taskId]) => taskId.startsWith(`wf-${runId.slice(0, 8)}`));
+
+  // Also query tasks repo to find which agents ran steps for this run
+  const runTasks = tasksRepo.getAll?.().filter((t: any) => t.workflowRunId === runId) ?? [];
+
+  const instanceNames = new Set<string>();
+
+  for (const task of runTasks) {
+    if (!task.toAgent) continue;
+    const agentRecord = agentsRepo.getAll().find((a: any) => a.name === task.toAgent);
+    const instance = agentRecord?.instanceId ? instancesRepo.getById(agentRecord.instanceId) : undefined;
+    if (instance?.name) {
+      instanceNames.add(instance.name);
+    }
+  }
+
+  if (instanceNames.size === 0) {
+    // No agents found — nothing to clean up
+    console.log(`[workflow-dispatcher] No instances found for run ${runId.slice(0, 8)} — skipping workspace cleanup`);
+    return;
+  }
+
+  for (const instanceName of instanceNames) {
+    try {
+      const agentRecord = agentsRepo.getAll().find((a: any) => {
+        const inst = a.instanceId ? instancesRepo.getById(a.instanceId) : undefined;
+        return inst?.name === instanceName;
+      });
+      const instance = agentRecord?.instanceId ? instancesRepo.getById(agentRecord.instanceId) : undefined;
+      if (!instance?.nodeId) continue;
+
+      const wsNode = getNodeClient(instance.nodeId);
+      const result = await wsNode.cleanupWorkspaces(instanceName, runId);
+      console.log(`[workflow-dispatcher] Cleaned up ${result.cleaned} worktree(s) for run ${runId.slice(0, 8)} on instance ${instanceName}`);
+    } catch (err: any) {
+      console.warn(`[workflow-dispatcher] Workspace cleanup failed for run ${runId.slice(0, 8)} on instance ${instanceName}: ${err.message}`);
+    }
+  }
 }
 
 /**

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -234,6 +234,7 @@ interface NotifyOptions {
 
 let _dispatchFn: DispatchFn | null = null;
 let _notifyFn: ((opts: NotifyOptions) => void) | null = null;
+let _cleanupWorkspacesFn: ((run: { id: string }) => Promise<void>) | null = null;
 
 export function setWorkflowDispatcher(fn: DispatchFn) {
   _dispatchFn = fn;
@@ -241,6 +242,14 @@ export function setWorkflowDispatcher(fn: DispatchFn) {
 
 export function setWorkflowNotifier(fn: (opts: NotifyOptions) => void) {
   _notifyFn = fn;
+}
+
+/**
+ * Register a callback to clean up workspace worktrees when a run finishes.
+ * Called fire-and-forget after a run transitions to completed/failed/cancelled.
+ */
+export function setWorkspaceCleanupFn(fn: (run: { id: string }) => Promise<void>) {
+  _cleanupWorkspacesFn = fn;
 }
 
 // ── Start a workflow run ────────────────────────────────────────────
@@ -414,6 +423,16 @@ async function advanceRun(
     getDrizzle().run(sql`
       UPDATE workflow_runs SET status = ${finalStatus}, completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ${run.id}
     `);
+
+    // ── Clean up workspace worktrees for this run ──────────────────────
+    if (_cleanupWorkspacesFn) {
+      const completedRun = getRunById(run.id);
+      if (completedRun) {
+        _cleanupWorkspacesFn(completedRun).catch((err: Error) => {
+          console.error(`[workflow-engine] Workspace cleanup failed for run ${run.id}: ${err.message}`);
+        });
+      }
+    }
 
     // ── Auto-close GitHub issue on workflow completion ──────────────────
     if (finalStatus === 'completed' && run.triggerRef) {
@@ -1201,6 +1220,16 @@ export async function cancelRun(runId: string): Promise<void> {
   db.run(sql`UPDATE workflow_runs SET status = 'cancelled', completed_at = ${now} WHERE id = ${runId}`);
   db.run(sql`UPDATE workflow_step_runs SET status = 'cancelled', completed_at = ${now} WHERE run_id = ${runId} AND status = 'running'`);
   db.run(sql`UPDATE workflow_step_runs SET status = 'skipped' WHERE run_id = ${runId} AND status IN ('pending', 'waiting_gate', 'waiting_for_rework')`);
+
+  // Clean up workspace worktrees for this run
+  if (_cleanupWorkspacesFn) {
+    const cancelledRun = getRunById(runId);
+    if (cancelledRun) {
+      _cleanupWorkspacesFn(cancelledRun).catch((err: Error) => {
+        console.error(`[workflow-engine] Workspace cleanup failed for cancelled run ${runId}: ${err.message}`);
+      });
+    }
+  }
 
   // Fire-and-forget abort requests to running agents
   for (const stepRun of runningSteps) {

--- a/packages/node/src/handlers/workspace.ts
+++ b/packages/node/src/handlers/workspace.ts
@@ -239,10 +239,273 @@ export async function handleWorkspaceDiscover(msg: CommandMessage): Promise<Resp
   }
 }
 
+export async function handleWorkspaceProvision(msg: CommandMessage): Promise<ResponseMessage> {
+  const params = msg.params as {
+    instanceId: string;
+    repo: string;
+    branch: string;
+    stepId: string;
+    runId: string;
+    installCmd?: string;
+  };
+
+  const { instanceId, repo, branch, stepId, runId, installCmd } = params;
+  if (!instanceId || !repo || !branch || !stepId || !runId) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: 'instanceId, repo, branch, stepId, and runId are required',
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+
+  // Parse org and repo name from "owner/repo" or full https URL
+  let repoOrg: string;
+  let repoName: string;
+  try {
+    if (repo.startsWith('https://') || repo.startsWith('git@')) {
+      const urlPart = repo.replace(/\.git$/, '').split(/[:/]/).slice(-2);
+      repoOrg = urlPart[0];
+      repoName = urlPart[1];
+    } else {
+      const parts = repo.split('/');
+      repoOrg = parts[parts.length - 2] || 'org';
+      repoName = parts[parts.length - 1] || 'repo';
+    }
+  } catch {
+    repoOrg = 'org';
+    repoName = repo.split('/').pop() || 'repo';
+  }
+
+  const basePath = `/data/repos/${repoOrg}/${repoName}`;
+  const runPrefix = runId.slice(0, 8);
+  const worktreePath = `/data/worktrees/${runPrefix}/${stepId}`;
+
+  console.log(`[workspace] Provisioning worktree for run ${runPrefix}, step ${stepId}: ${worktreePath}`);
+
+  try {
+    // Step 1: Ensure base repo exists or clone it
+    const checkBase = await containerExec(instanceId, [
+      'sh', '-c', `test -d "${basePath}/.git" && echo "exists" || echo "missing"`,
+    ]);
+
+    if (checkBase.output.trim() === 'missing') {
+      console.log(`[workspace] Base repo not found — cloning ${repo} to ${basePath}`);
+      const mkdirResult = await containerExec(instanceId, ['mkdir', '-p', `/data/repos/${repoOrg}`]);
+      if (mkdirResult.exitCode !== 0) {
+        console.warn(`[workspace] mkdir failed: ${mkdirResult.output}`);
+      }
+      const cloneUrl = repo.startsWith('https://') || repo.startsWith('git@')
+        ? repo
+        : `https://github.com/${repo}.git`;
+      const cloneResult = await containerExec(instanceId, ['git', 'clone', cloneUrl, basePath]);
+      if (cloneResult.exitCode !== 0) {
+        return {
+          type: 'response',
+          id: msg.id,
+          status: 'error',
+          error: `git clone failed: ${cloneResult.output}`,
+          code: WsErrorCode.UNKNOWN,
+        };
+      }
+    } else {
+      // Fetch latest changes
+      console.log(`[workspace] Fetching latest changes in ${basePath}`);
+      const fetchResult = await containerExec(instanceId, [
+        'git', '-C', basePath, 'fetch', 'origin',
+      ]);
+      if (fetchResult.exitCode !== 0) {
+        console.warn(`[workspace] git fetch failed (non-fatal): ${fetchResult.output}`);
+      }
+    }
+
+    // Step 2: Create worktree directory parent
+    const mkWorktreeParent = await containerExec(instanceId, [
+      'mkdir', '-p', `/data/worktrees/${runPrefix}`,
+    ]);
+    if (mkWorktreeParent.exitCode !== 0) {
+      console.warn(`[workspace] mkdir for worktrees dir failed: ${mkWorktreeParent.output}`);
+    }
+
+    // Step 3: Add worktree
+    const worktreeResult = await containerExec(instanceId, [
+      'git', '-C', basePath, 'worktree', 'add', worktreePath, '-b', branch, 'origin/main',
+    ]);
+    if (worktreeResult.exitCode !== 0) {
+      return {
+        type: 'response',
+        id: msg.id,
+        status: 'error',
+        error: `git worktree add failed: ${worktreeResult.output}`,
+        code: WsErrorCode.UNKNOWN,
+      };
+    }
+
+    // Step 4: Run install
+    if (installCmd) {
+      console.log(`[workspace] Running custom install command in ${worktreePath}`);
+      const installResult = await containerExec(instanceId, [
+        'sh', '-c', `cd "${worktreePath}" && ${installCmd}`,
+      ]);
+      if (installResult.exitCode !== 0) {
+        console.warn(`[workspace] Custom install failed (non-fatal): ${installResult.output}`);
+      }
+    } else {
+      // Check for armada.json first
+      const checkArmada = await containerExec(instanceId, [
+        'sh', '-c', `test -f "${worktreePath}/armada.json" && echo "yes" || echo "no"`,
+      ]);
+
+      if (checkArmada.output.trim() === 'yes') {
+        // Read install command from armada.json
+        const armadaReadResult = await containerExec(instanceId, [
+          'sh', '-c', `cat "${worktreePath}/armada.json"`,
+        ]);
+        if (armadaReadResult.exitCode === 0) {
+          try {
+            const armadaConfig = JSON.parse(armadaReadResult.output);
+            if (armadaConfig.install) {
+              console.log(`[workspace] Running armada.json install: ${armadaConfig.install}`);
+              const armadaInstallResult = await containerExec(instanceId, [
+                'sh', '-c', `cd "${worktreePath}" && ${armadaConfig.install}`,
+              ]);
+              if (armadaInstallResult.exitCode !== 0) {
+                console.warn(`[workspace] armada.json install failed (non-fatal): ${armadaInstallResult.output}`);
+              }
+            }
+          } catch {
+            console.warn(`[workspace] Failed to parse armada.json`);
+          }
+        }
+      } else {
+        // Check for package.json and run npm ci
+        const checkPkg = await containerExec(instanceId, [
+          'sh', '-c', `test -f "${worktreePath}/package.json" && echo "yes" || echo "no"`,
+        ]);
+
+        if (checkPkg.output.trim() === 'yes') {
+          console.log(`[workspace] Found package.json — running npm ci in ${worktreePath}`);
+          // Use base repo's node_modules cache via npm cache
+          const npmCiResult = await containerExec(instanceId, [
+            'sh', '-c', `cd "${worktreePath}" && npm ci --prefer-offline 2>&1 || npm install 2>&1`,
+          ]);
+          if (npmCiResult.exitCode !== 0) {
+            console.warn(`[workspace] npm ci failed (non-fatal): ${npmCiResult.output}`);
+          }
+        }
+      }
+    }
+
+    console.log(`[workspace] Worktree ready: ${instanceId}:${worktreePath} (branch: ${branch})`);
+
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { path: worktreePath, branch, status: 'ready' },
+    };
+  } catch (err: any) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: `Workspace provision failed: ${err.message}`,
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+}
+
+export async function handleWorkspaceCleanup(msg: CommandMessage): Promise<ResponseMessage> {
+  const params = msg.params as {
+    instanceId: string;
+    runId: string;
+  };
+
+  const { instanceId, runId } = params;
+  if (!instanceId || !runId) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: 'instanceId and runId are required',
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+
+  const runPrefix = runId.slice(0, 8);
+  const runDir = `/data/worktrees/${runPrefix}`;
+
+  console.log(`[workspace] Cleaning up worktrees for run ${runPrefix} in ${instanceId}`);
+
+  try {
+    // Find all worktrees under the run directory
+    const listResult = await containerExec(instanceId, [
+      'sh', '-c', `find "${runDir}" -maxdepth 1 -mindepth 1 -type d 2>/dev/null || echo ""`,
+    ]);
+
+    const worktreePaths = listResult.output
+      .split('\n')
+      .map(p => p.trim())
+      .filter(p => p.length > 0);
+
+    let cleaned = 0;
+
+    for (const wt of worktreePaths) {
+      // Identify the base repo for this worktree (by checking which repo manages it)
+      // Use git worktree remove from within the worktree's git directory
+      const removeResult = await containerExec(instanceId, [
+        'sh', '-c', `
+          BASE=$(git -C "${wt}" rev-parse --git-common-dir 2>/dev/null | sed 's|/.git||' | sed 's|/\\.git$||')
+          if [ -n "$BASE" ] && [ "$BASE" != "." ]; then
+            git -C "$BASE" worktree remove "${wt}" --force 2>&1
+          else
+            rm -rf "${wt}"
+          fi
+        `,
+      ]);
+
+      if (removeResult.exitCode !== 0) {
+        console.warn(`[workspace] Failed to remove worktree ${wt} (non-fatal): ${removeResult.output}`);
+        // Force remove the directory as fallback
+        await containerExec(instanceId, ['rm', '-rf', wt]);
+      }
+      cleaned++;
+    }
+
+    // Remove the run directory itself
+    const rmDirResult = await containerExec(instanceId, ['rm', '-rf', runDir]);
+    if (rmDirResult.exitCode !== 0) {
+      console.warn(`[workspace] Failed to remove run dir ${runDir}: ${rmDirResult.output}`);
+    }
+
+    console.log(`[workspace] Cleaned ${cleaned} worktree(s) for run ${runPrefix}`);
+
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'ok',
+      data: { cleaned },
+    };
+  } catch (err: any) {
+    return {
+      type: 'response',
+      id: msg.id,
+      status: 'error',
+      error: `Workspace cleanup failed: ${err.message}`,
+      code: WsErrorCode.UNKNOWN,
+    };
+  }
+}
+
 export async function handleWorkspaceCommand(msg: CommandMessage): Promise<ResponseMessage> {
   switch (msg.action) {
     case 'workspace.clone':
       return handleWorkspaceClone(msg);
+    case 'workspace.provision':
+      return handleWorkspaceProvision(msg);
+    case 'workspace.cleanup':
+      return handleWorkspaceCleanup(msg);
     case 'workspace.discover':
       return handleWorkspaceDiscover(msg);
     case 'workspace.exec':


### PR DESCRIPTION
Closes #175

### What it does
- **Base repo management**: First clone to /data/repos/, then git fetch on subsequent runs
- **Worktree per step**: /data/worktrees/{runId}/{stepId} — isolated, lightweight
- **Auto-install**: reads armada.json > package.json > npm ci
- **Lifecycle cleanup**: worktrees removed on workflow completion/failure/cancel
- **Backwards compatible**: workspace.clone still works

### Files (4 files, 399 additions)
- Node: workspace.ts (provision + cleanup handlers)
- Control: ws-node-client (provisionWorkspace + cleanupWorkspaces)
- Dispatcher: uses provisionWorkspace, registers cleanup hook
- Engine: calls cleanup on run completion/failure/cancel

0 TS errors, 163 tests pass.