### PR TITLE
feat: codebase intelligence — indexer package + control plane tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,6 +327,10 @@
       "resolved": "plugins/control",
       "link": true
     },
+    "node_modules/@coderage-labs/armada-indexer": {
+      "resolved": "packages/indexer",
+      "link": true
+    },
     "node_modules/@coderage-labs/armada-node": {
       "resolved": "packages/node",
       "link": true
@@ -3795,6 +3799,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
@@ -4300,6 +4344,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4394,6 +4448,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4691,6 +4755,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -6892,6 +6966,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -7362,6 +7443,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8781,10 +8872,30 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9116,6 +9227,43 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -9884,6 +10032,7 @@
       "name": "@coderage-labs/armada-control",
       "version": "0.3.0",
       "dependencies": {
+        "@coderage-labs/armada-indexer": "file:../indexer",
         "@coderage-labs/armada-shared": "*",
         "@simplewebauthn/server": "^11.0.0",
         "@slack/bolt": "^4.6.0",
@@ -10442,6 +10591,247 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "packages/indexer": {
+      "name": "@coderage-labs/armada-indexer",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^11.7.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.4",
+        "vitest": "^2.0.5"
+      }
+    },
+    "packages/indexer/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/indexer/node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "packages/indexer/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/indexer/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/indexer/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/indexer/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/indexer/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/indexer/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/indexer/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "packages/node": {

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -36,7 +36,8 @@
     "sharp": "^0.33.5",
     "uuid": "^13.0.0",
     "ws": "^8.19.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@coderage-labs/armada-indexer": "file:../indexer"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -53,6 +53,7 @@ import { installScriptRoutes } from './routes/install-script.js';
 import { notificationChannelsRoutes } from './routes/notification-channels.js';
 import workflowArtifactRoutes from './routes/workflow-artifacts.js';
 import projectReposRoutes from './routes/project-repos.js';
+import { codebaseRouter } from './routes/codebase.js';
 
 export interface AppOptions {
   nodeManager: NodeManager;
@@ -117,6 +118,7 @@ export function createApp(opts: AppOptions): express.Express {
   app.use('/api/projects/:id/assignments', assignmentRoutes);
   app.use('/api/projects/:id/integrations', createProjectIntegrationRoutes(nodeManager));
   app.use('/api/projects/:id/repos2', projectReposRoutes);
+  app.use('/api/codebase', codebaseRouter);
   app.use('/api/webhooks', webhookRoutes);
   app.use('/api/webhooks/inbound', webhooksInboundMgmtRouter);
   app.use('/api/tools', createToolRoutes(nodeManager));

--- a/packages/control/src/repositories/project-repos-repo.ts
+++ b/packages/control/src/repositories/project-repos-repo.ts
@@ -55,6 +55,15 @@ export const projectReposRepo = {
     return row ? rowToProjectRepo(row) : null;
   },
 
+  getByFullName(fullName: string): ProjectRepo[] {
+    return getDrizzle()
+      .select()
+      .from(projectRepos)
+      .where(eq(projectRepos.fullName, fullName))
+      .all()
+      .map(rowToProjectRepo);
+  },
+
   getByProjectAndName(projectId: string, fullName: string): ProjectRepo | null {
     const row = getDrizzle()
       .select()

--- a/packages/control/src/routes/codebase.ts
+++ b/packages/control/src/routes/codebase.ts
@@ -1,0 +1,180 @@
+/**
+ * Codebase intelligence API routes.
+ * Exposes the knowledge graph via Armada tool-compatible endpoints.
+ */
+
+import { Router } from 'express';
+import { resolve } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { requireScope } from '../middleware/scopes.js';
+import { registerToolDef } from '../utils/tool-registry.js';
+import { projectReposRepo } from '../repositories/project-repos-repo.js';
+import { integrationsRepo } from '../services/integrations/integrations-repo.js';
+import { GraphStore, indexRepository } from '@coderage-labs/armada-indexer';
+
+// ── Tool definitions (inline to avoid cross-package import issues) ──
+
+const CODEBASE_TOOLS = [
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_search', description: 'Search for files and symbols across indexed repositories.', method: 'POST', path: '/api/codebase/search',
+    parameters: [{ name: 'query', type: 'string', description: 'Search query', required: true }, { name: 'repo', type: 'string', description: 'Repository full name (optional)' }, { name: 'kind', type: 'string', description: 'Filter: function, class, interface, type, method' }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_dependencies', description: 'Get dependency graph for a file — what it imports and what imports it.', method: 'POST', path: '/api/codebase/dependencies',
+    parameters: [{ name: 'file', type: 'string', description: 'File path in repo', required: true }, { name: 'repo', type: 'string', description: 'Repository full name', required: true }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_callers', description: 'Find callers of a function/symbol and what it calls.', method: 'POST', path: '/api/codebase/callers',
+    parameters: [{ name: 'symbol', type: 'string', description: 'Symbol name', required: true }, { name: 'repo', type: 'string', description: 'Repository full name (optional)' }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_impact', description: 'Impact analysis — direct/transitive dependents, risk level.', method: 'POST', path: '/api/codebase/impact',
+    parameters: [{ name: 'file', type: 'string', description: 'File path in repo', required: true }, { name: 'repo', type: 'string', description: 'Repository full name', required: true }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_architecture', description: 'High-level repo architecture — dirs, languages, import hubs.', method: 'POST', path: '/api/codebase/architecture',
+    parameters: [{ name: 'repo', type: 'string', description: 'Repository full name', required: true }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_file_context', description: 'Full context for a file — symbols, imports, importers.', method: 'POST', path: '/api/codebase/file-context',
+    parameters: [{ name: 'file', type: 'string', description: 'File path in repo', required: true }, { name: 'repo', type: 'string', description: 'Repository full name', required: true }] },
+  { category: 'codebase', scope: 'projects:write', name: 'armada_code_index', description: 'Trigger indexing/re-indexing of a repository.', method: 'POST', path: '/api/codebase/index',
+    parameters: [{ name: 'repo', type: 'string', description: 'Repository full name', required: true }, { name: 'force', type: 'string', description: 'Set to "true" to force full re-index' }] },
+  { category: 'codebase', scope: 'projects:read', name: 'armada_code_index_status', description: 'Check indexing status of a repository.', method: 'POST', path: '/api/codebase/index-status',
+    parameters: [{ name: 'repo', type: 'string', description: 'Repository full name', required: true }] },
+] as const;
+
+// ── Graph store singleton ───────────────────────────────────────────
+
+const DB_DIR = process.env.ARMADA_DB_DIR || '/data';
+const DB_PATH = resolve(DB_DIR, 'codebase-graph.db');
+const REPOS_DIR = resolve(DB_DIR, 'repos');
+let _store: GraphStore | null = null;
+
+function getStore(): GraphStore {
+  if (!_store) {
+    const dir = resolve(DB_PATH, '..');
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    _store = new GraphStore(DB_PATH);
+  }
+  return _store;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function resolveTokenForRepo(repoFullName: string): string {
+  try {
+    const repos = projectReposRepo.getByFullName(repoFullName);
+    for (const repo of repos) {
+      if (repo.integrationId) {
+        const integration = integrationsRepo.getById(repo.integrationId);
+        if (integration?.authConfig?.token) return integration.authConfig.token as string;
+      }
+    }
+  } catch { /* ignore */ }
+  return process.env.GITHUB_TOKEN || '';
+}
+
+function ensureRepoClone(repoFullName: string, token?: string): string {
+  const repoDir = resolve(REPOS_DIR, repoFullName.replace('/', '-'));
+  if (!existsSync(REPOS_DIR)) mkdirSync(REPOS_DIR, { recursive: true });
+
+  const authUrl = token
+    ? `https://x-access-token:${token}@github.com/${repoFullName}.git`
+    : `https://github.com/${repoFullName}.git`;
+
+  if (existsSync(resolve(repoDir, '.git'))) {
+    try {
+      execSync('git fetch origin', { cwd: repoDir, stdio: 'pipe', timeout: 60_000 });
+      execSync('git reset --hard origin/HEAD', { cwd: repoDir, stdio: 'pipe', timeout: 30_000 });
+    } catch (err: any) {
+      console.warn(`[codebase] Git fetch failed for ${repoFullName}: ${err.message}`);
+    }
+  } else {
+    execSync(`git clone --depth 1 ${authUrl} ${repoDir}`, { stdio: 'pipe', timeout: 120_000 });
+  }
+
+  return repoDir;
+}
+
+// ── Router ──────────────────────────────────────────────────────────
+
+export const codebaseRouter = Router();
+
+// Register tool definitions
+for (const tool of CODEBASE_TOOLS) {
+  registerToolDef(tool as any);
+}
+
+codebaseRouter.post('/search', requireScope('projects:read'), (req, res) => {
+  const { query, repo, kind } = req.body;
+  if (!query) return res.status(400).json({ error: 'query is required' });
+  const store = getStore();
+  const files = store.searchFiles(query, repo);
+  let symbols = store.searchSymbols(query, repo);
+  if (kind) symbols = symbols.filter((s: any) => s.kind === kind);
+  res.json({ files: files.slice(0, 20), symbols: symbols.slice(0, 30) });
+});
+
+codebaseRouter.post('/dependencies', requireScope('projects:read'), (req, res) => {
+  const { file, repo } = req.body;
+  if (!file || !repo) return res.status(400).json({ error: 'file and repo required' });
+  const store = getStore();
+  const result = store.getDependencies(`${repo}:${file}`);
+  if (!result) return res.status(404).json({ error: 'File not found in index' });
+  res.json(result);
+});
+
+codebaseRouter.post('/callers', requireScope('projects:read'), (req, res) => {
+  const { symbol, repo } = req.body;
+  if (!symbol) return res.status(400).json({ error: 'symbol is required' });
+  const store = getStore();
+  const result = store.getCallers(symbol, repo);
+  if (!result) return res.status(404).json({ error: 'Symbol not found' });
+  res.json(result);
+});
+
+codebaseRouter.post('/impact', requireScope('projects:read'), (req, res) => {
+  const { file, repo } = req.body;
+  if (!file || !repo) return res.status(400).json({ error: 'file and repo required' });
+  const store = getStore();
+  const result = store.getImpact(`${repo}:${file}`);
+  if (!result) return res.status(404).json({ error: 'File not found in index' });
+  res.json(result);
+});
+
+codebaseRouter.post('/architecture', requireScope('projects:read'), (req, res) => {
+  const { repo } = req.body;
+  if (!repo) return res.status(400).json({ error: 'repo is required' });
+  const store = getStore();
+  res.json(store.getArchitecture(repo));
+});
+
+codebaseRouter.post('/file-context', requireScope('projects:read'), (req, res) => {
+  const { file, repo } = req.body;
+  if (!file || !repo) return res.status(400).json({ error: 'file and repo required' });
+  const store = getStore();
+  const fileId = `${repo}:${file}`;
+  const fileNode = store.getFile(fileId);
+  if (!fileNode) return res.status(404).json({ error: 'File not found in index' });
+  const symbols = store.getSymbolsByFile(fileId);
+  const deps = store.getDependencies(fileId);
+  res.json({ file: fileNode, symbols, imports: deps?.imports || [], importedBy: deps?.importedBy || [] });
+});
+
+codebaseRouter.post('/index', requireScope('projects:write'), async (req, res) => {
+  const { repo, force } = req.body;
+  if (!repo) return res.status(400).json({ error: 'repo is required' });
+  try {
+    const token = resolveTokenForRepo(repo);
+    const repoDir = ensureRepoClone(repo, token);
+    const store = getStore();
+    const result = await indexRepository({
+      repoId: repo, repoFullName: repo, repoPath: repoDir, store,
+      incremental: force !== 'true' && force !== true,
+      onProgress: (msg) => console.log(`[codebase] ${msg}`),
+    });
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+codebaseRouter.post('/index-status', requireScope('projects:read'), (req, res) => {
+  const { repo } = req.body;
+  if (!repo) return res.status(400).json({ error: 'repo is required' });
+  const store = getStore();
+  const index = store.getRepoIndex(repo);
+  if (!index) return res.json({ indexed: false });
+  res.json({ indexed: true, ...index });
+});

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@coderage-labs/armada-indexer",
+  "version": "0.1.0",
+  "description": "Codebase intelligence indexer \u2014 tree-sitter AST parsing into a queryable knowledge graph",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.7.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}

--- a/packages/indexer/src/graph/index.ts
+++ b/packages/indexer/src/graph/index.ts
@@ -1,0 +1,6 @@
+export { GraphStore } from './store.js';
+export type {
+  FileNode, SymbolNode, ImportEdge, ReferenceEdge,
+  RepoIndex, Language, SymbolKind, ReferenceKind,
+  SearchResult, DependencyResult, CallerResult, ImpactResult,
+} from './schema.js';

--- a/packages/indexer/src/graph/schema.ts
+++ b/packages/indexer/src/graph/schema.ts
@@ -1,0 +1,120 @@
+/**
+ * Knowledge graph schema — language-agnostic codebase representation.
+ *
+ * Nodes: files, symbols (functions, classes, types, etc.)
+ * Edges: imports, calls, type references, exports
+ */
+
+// ── Node types ──────────────────────────────────────────────────────
+
+export interface FileNode {
+  id: string;             // repo:path
+  repoId: string;         // project_repo ID
+  path: string;           // relative path within repo
+  language: Language;
+  size: number;           // bytes
+  hash: string;           // content hash for change detection
+  lineCount: number;
+  indexedAt: string;       // ISO timestamp
+}
+
+export interface SymbolNode {
+  id: string;             // repo:path:name:line
+  fileId: string;         // references FileNode.id
+  name: string;
+  kind: SymbolKind;
+  line: number;
+  endLine?: number;
+  signature?: string;     // e.g. "function foo(x: number): string"
+  exported: boolean;
+  documentation?: string; // JSDoc / docstring
+}
+
+// ── Edge types ──────────────────────────────────────────────────────
+
+export interface ImportEdge {
+  id: string;
+  fromFileId: string;     // importing file
+  toFileId: string;       // imported file (resolved)
+  toModule: string;       // raw import path (e.g. './utils', 'express')
+  symbols: string[];      // named imports: ['foo', 'bar']
+  isDefault: boolean;
+  isNamespace: boolean;   // import * as X
+  line: number;
+}
+
+export interface ReferenceEdge {
+  id: string;
+  fromSymbolId: string;   // caller/user
+  toSymbolId: string;     // callee/referenced
+  kind: ReferenceKind;
+  line: number;
+}
+
+// ── Enums ───────────────────────────────────────────────────────────
+
+export type Language =
+  | 'typescript' | 'javascript' | 'tsx' | 'jsx'
+  | 'python' | 'go' | 'rust' | 'java'
+  | 'terraform' | 'sql' | 'css' | 'html'
+  | 'json' | 'yaml' | 'markdown'
+  | 'unknown';
+
+export type SymbolKind =
+  | 'function' | 'method' | 'class' | 'interface' | 'type'
+  | 'enum' | 'variable' | 'constant'
+  | 'struct' | 'trait' | 'impl'
+  | 'module' | 'namespace'
+  | 'resource' | 'data_source' | 'output'  // Terraform
+  | 'table' | 'view';                       // SQL
+
+export type ReferenceKind =
+  | 'call'        // function/method call
+  | 'import'      // import reference
+  | 'type_ref'    // type annotation reference
+  | 'extends'     // class/interface inheritance
+  | 'implements'  // interface implementation
+  | 'instantiate' // new ClassName()
+  | 'uses';       // general usage
+
+// ── Repo index metadata ─────────────────────────────────────────────
+
+export interface RepoIndex {
+  repoId: string;
+  fullName: string;       // e.g. "coderage-labs/demo-backend"
+  lastIndexedAt: string;
+  lastCommitHash: string;
+  fileCount: number;
+  symbolCount: number;
+  importCount: number;
+  languages: Record<Language, number>;  // file count per language
+  indexDurationMs: number;
+}
+
+// ── Query result types ──────────────────────────────────────────────
+
+export interface SearchResult {
+  file: FileNode;
+  symbols: SymbolNode[];
+  relevance: number;
+}
+
+export interface DependencyResult {
+  file: FileNode;
+  imports: Array<{ module: string; symbols: string[]; resolvedFile?: FileNode }>;
+  importedBy: Array<{ file: FileNode; symbols: string[] }>;
+}
+
+export interface CallerResult {
+  symbol: SymbolNode;
+  callers: Array<{ symbol: SymbolNode; file: FileNode; line: number }>;
+  callees: Array<{ symbol: SymbolNode; file: FileNode; line: number }>;
+}
+
+export interface ImpactResult {
+  file: FileNode;
+  directDependents: FileNode[];
+  transitiveDependents: FileNode[];
+  affectedSymbols: SymbolNode[];
+  riskLevel: 'low' | 'medium' | 'high' | 'critical';
+}

--- a/packages/indexer/src/graph/store.ts
+++ b/packages/indexer/src/graph/store.ts
@@ -1,0 +1,410 @@
+/**
+ * SQLite-backed graph store for the codebase knowledge graph.
+ * Stores files, symbols, imports, references, and repo metadata.
+ */
+
+import Database from 'better-sqlite3';
+import type {
+  FileNode, SymbolNode, ImportEdge, ReferenceEdge,
+  RepoIndex, Language, SearchResult, DependencyResult,
+  CallerResult, ImpactResult,
+} from './schema.js';
+
+export class GraphStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.init();
+  }
+
+  private init(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS repo_index (
+        repo_id TEXT PRIMARY KEY,
+        full_name TEXT NOT NULL,
+        last_indexed_at TEXT,
+        last_commit_hash TEXT,
+        file_count INTEGER DEFAULT 0,
+        symbol_count INTEGER DEFAULT 0,
+        import_count INTEGER DEFAULT 0,
+        languages_json TEXT DEFAULT '{}',
+        index_duration_ms INTEGER DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS files (
+        id TEXT PRIMARY KEY,
+        repo_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        language TEXT NOT NULL,
+        size INTEGER NOT NULL,
+        hash TEXT NOT NULL,
+        line_count INTEGER NOT NULL,
+        indexed_at TEXT NOT NULL,
+        UNIQUE(repo_id, path)
+      );
+
+      CREATE TABLE IF NOT EXISTS symbols (
+        id TEXT PRIMARY KEY,
+        file_id TEXT NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        line INTEGER NOT NULL,
+        end_line INTEGER,
+        signature TEXT,
+        exported INTEGER NOT NULL DEFAULT 0,
+        documentation TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS imports (
+        id TEXT PRIMARY KEY,
+        from_file_id TEXT NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+        to_file_id TEXT,
+        to_module TEXT NOT NULL,
+        symbols_json TEXT DEFAULT '[]',
+        is_default INTEGER NOT NULL DEFAULT 0,
+        is_namespace INTEGER NOT NULL DEFAULT 0,
+        line INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS references_ (
+        id TEXT PRIMARY KEY,
+        from_symbol_id TEXT NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+        to_symbol_id TEXT NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL,
+        line INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_files_repo ON files(repo_id);
+      CREATE INDEX IF NOT EXISTS idx_files_path ON files(repo_id, path);
+      CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_id);
+      CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+      CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+      CREATE INDEX IF NOT EXISTS idx_imports_from ON imports(from_file_id);
+      CREATE INDEX IF NOT EXISTS idx_imports_to ON imports(to_file_id);
+      CREATE INDEX IF NOT EXISTS idx_imports_module ON imports(to_module);
+      CREATE INDEX IF NOT EXISTS idx_refs_from ON references_(from_symbol_id);
+      CREATE INDEX IF NOT EXISTS idx_refs_to ON references_(to_symbol_id);
+    `);
+  }
+
+  // ── Repo index ──────────────────────────────────────────────────────
+
+  upsertRepoIndex(index: RepoIndex): void {
+    this.db.prepare(`
+      INSERT INTO repo_index (repo_id, full_name, last_indexed_at, last_commit_hash, file_count, symbol_count, import_count, languages_json, index_duration_ms)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(repo_id) DO UPDATE SET
+        full_name = excluded.full_name,
+        last_indexed_at = excluded.last_indexed_at,
+        last_commit_hash = excluded.last_commit_hash,
+        file_count = excluded.file_count,
+        symbol_count = excluded.symbol_count,
+        import_count = excluded.import_count,
+        languages_json = excluded.languages_json,
+        index_duration_ms = excluded.index_duration_ms
+    `).run(
+      index.repoId, index.fullName, index.lastIndexedAt, index.lastCommitHash,
+      index.fileCount, index.symbolCount, index.importCount,
+      JSON.stringify(index.languages), index.indexDurationMs,
+    );
+  }
+
+  getRepoIndex(repoId: string): RepoIndex | null {
+    const row = this.db.prepare('SELECT * FROM repo_index WHERE repo_id = ?').get(repoId) as any;
+    if (!row) return null;
+    return {
+      repoId: row.repo_id,
+      fullName: row.full_name,
+      lastIndexedAt: row.last_indexed_at,
+      lastCommitHash: row.last_commit_hash,
+      fileCount: row.file_count,
+      symbolCount: row.symbol_count,
+      importCount: row.import_count,
+      languages: JSON.parse(row.languages_json || '{}'),
+      indexDurationMs: row.index_duration_ms,
+    };
+  }
+
+  // ── Files ─────────────────────────────────────────────────────────
+
+  upsertFile(file: FileNode): void {
+    this.db.prepare(`
+      INSERT INTO files (id, repo_id, path, language, size, hash, line_count, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        language = excluded.language, size = excluded.size, hash = excluded.hash,
+        line_count = excluded.line_count, indexed_at = excluded.indexed_at
+    `).run(file.id, file.repoId, file.path, file.language, file.size, file.hash, file.lineCount, file.indexedAt);
+  }
+
+  getFile(id: string): FileNode | null {
+    const row = this.db.prepare('SELECT * FROM files WHERE id = ?').get(id) as any;
+    return row ? this.rowToFile(row) : null;
+  }
+
+  getFilesByRepo(repoId: string): FileNode[] {
+    return (this.db.prepare('SELECT * FROM files WHERE repo_id = ? ORDER BY path').all(repoId) as any[]).map(r => this.rowToFile(r));
+  }
+
+  deleteFilesByRepo(repoId: string): void {
+    this.db.prepare('DELETE FROM files WHERE repo_id = ?').run(repoId);
+  }
+
+  private rowToFile(row: any): FileNode {
+    return {
+      id: row.id, repoId: row.repo_id, path: row.path,
+      language: row.language as Language, size: row.size,
+      hash: row.hash, lineCount: row.line_count, indexedAt: row.indexed_at,
+    };
+  }
+
+  // ── Symbols ───────────────────────────────────────────────────────
+
+  insertSymbol(symbol: SymbolNode): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO symbols (id, file_id, name, kind, line, end_line, signature, exported, documentation)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(symbol.id, symbol.fileId, symbol.name, symbol.kind, symbol.line,
+      symbol.endLine ?? null, symbol.signature ?? null, symbol.exported ? 1 : 0,
+      symbol.documentation ?? null);
+  }
+
+  getSymbolsByFile(fileId: string): SymbolNode[] {
+    return (this.db.prepare('SELECT * FROM symbols WHERE file_id = ?').all(fileId) as any[]).map(r => this.rowToSymbol(r));
+  }
+
+  searchSymbols(query: string, repoId?: string): SymbolNode[] {
+    const pattern = `%${query}%`;
+    if (repoId) {
+      return (this.db.prepare(`
+        SELECT s.* FROM symbols s
+        JOIN files f ON f.id = s.file_id
+        WHERE s.name LIKE ? AND f.repo_id = ?
+        ORDER BY s.exported DESC, s.name
+        LIMIT 50
+      `).all(pattern, repoId) as any[]).map(r => this.rowToSymbol(r));
+    }
+    return (this.db.prepare(`
+      SELECT * FROM symbols WHERE name LIKE ? ORDER BY exported DESC, name LIMIT 50
+    `).all(pattern) as any[]).map(r => this.rowToSymbol(r));
+  }
+
+  deleteSymbolsByFile(fileId: string): void {
+    this.db.prepare('DELETE FROM symbols WHERE file_id = ?').run(fileId);
+  }
+
+  private rowToSymbol(row: any): SymbolNode {
+    return {
+      id: row.id, fileId: row.file_id, name: row.name,
+      kind: row.kind, line: row.line, endLine: row.end_line ?? undefined,
+      signature: row.signature ?? undefined, exported: !!row.exported,
+      documentation: row.documentation ?? undefined,
+    };
+  }
+
+  // ── Imports ───────────────────────────────────────────────────────
+
+  insertImport(edge: ImportEdge): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO imports (id, from_file_id, to_file_id, to_module, symbols_json, is_default, is_namespace, line)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(edge.id, edge.fromFileId, edge.toFileId ?? null, edge.toModule,
+      JSON.stringify(edge.symbols), edge.isDefault ? 1 : 0, edge.isNamespace ? 1 : 0, edge.line);
+  }
+
+  getImportsByFile(fileId: string): ImportEdge[] {
+    return (this.db.prepare('SELECT * FROM imports WHERE from_file_id = ?').all(fileId) as any[]).map(r => this.rowToImport(r));
+  }
+
+  getImportersOf(fileId: string): ImportEdge[] {
+    return (this.db.prepare('SELECT * FROM imports WHERE to_file_id = ?').all(fileId) as any[]).map(r => this.rowToImport(r));
+  }
+
+  deleteImportsByFile(fileId: string): void {
+    this.db.prepare('DELETE FROM imports WHERE from_file_id = ?').run(fileId);
+  }
+
+  private rowToImport(row: any): ImportEdge {
+    return {
+      id: row.id, fromFileId: row.from_file_id, toFileId: row.to_file_id,
+      toModule: row.to_module, symbols: JSON.parse(row.symbols_json || '[]'),
+      isDefault: !!row.is_default, isNamespace: !!row.is_namespace, line: row.line,
+    };
+  }
+
+  // ── References ────────────────────────────────────────────────────
+
+  insertReference(edge: ReferenceEdge): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO references_ (id, from_symbol_id, to_symbol_id, kind, line)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(edge.id, edge.fromSymbolId, edge.toSymbolId, edge.kind, edge.line);
+  }
+
+  // ── Queries ───────────────────────────────────────────────────────
+
+  searchFiles(query: string, repoId?: string): FileNode[] {
+    const pattern = `%${query}%`;
+    if (repoId) {
+      return (this.db.prepare('SELECT * FROM files WHERE path LIKE ? AND repo_id = ? ORDER BY path LIMIT 50').all(pattern, repoId) as any[]).map(r => this.rowToFile(r));
+    }
+    return (this.db.prepare('SELECT * FROM files WHERE path LIKE ? ORDER BY path LIMIT 50').all(pattern) as any[]).map(r => this.rowToFile(r));
+  }
+
+  getDependencies(fileId: string): DependencyResult | null {
+    const file = this.getFile(fileId);
+    if (!file) return null;
+    const imports = this.getImportsByFile(fileId);
+    const importedBy = this.getImportersOf(fileId);
+
+    return {
+      file,
+      imports: imports.map(i => ({
+        module: i.toModule,
+        symbols: i.symbols,
+        resolvedFile: i.toFileId ? this.getFile(i.toFileId) ?? undefined : undefined,
+      })),
+      importedBy: importedBy.map(i => ({
+        file: this.getFile(i.fromFileId)!,
+        symbols: i.symbols,
+      })).filter(i => i.file),
+    };
+  }
+
+  getCallers(symbolName: string, repoId?: string): CallerResult | null {
+    const symbols = this.searchSymbols(symbolName, repoId);
+    if (symbols.length === 0) return null;
+    const symbol = symbols[0]; // Best match
+
+    const callers = (this.db.prepare(`
+      SELECT r.*, s.*, f.* FROM references_ r
+      JOIN symbols s ON s.id = r.from_symbol_id
+      JOIN files f ON f.id = s.file_id
+      WHERE r.to_symbol_id = ?
+    `).all(symbol.id) as any[]).map(r => ({
+      symbol: this.rowToSymbol(r),
+      file: this.rowToFile(r),
+      line: r.line,
+    }));
+
+    const callees = (this.db.prepare(`
+      SELECT r.*, s.*, f.* FROM references_ r
+      JOIN symbols s ON s.id = r.to_symbol_id
+      JOIN files f ON f.id = s.file_id
+      WHERE r.from_symbol_id = ?
+    `).all(symbol.id) as any[]).map(r => ({
+      symbol: this.rowToSymbol(r),
+      file: this.rowToFile(r),
+      line: r.line,
+    }));
+
+    return { symbol, callers, callees };
+  }
+
+  getImpact(fileId: string): ImpactResult | null {
+    const file = this.getFile(fileId);
+    if (!file) return null;
+
+    // Direct dependents — files that import this file
+    const directImporters = this.getImportersOf(fileId);
+    const directDependents = directImporters
+      .map(i => this.getFile(i.fromFileId))
+      .filter((f): f is FileNode => f !== null);
+
+    // Transitive dependents — BFS through import graph
+    const visited = new Set<string>([fileId]);
+    const queue = directDependents.map(f => f.id);
+    const transitiveDependents: FileNode[] = [];
+
+    while (queue.length > 0) {
+      const currentId = queue.shift()!;
+      if (visited.has(currentId)) continue;
+      visited.add(currentId);
+
+      const current = this.getFile(currentId);
+      if (current) transitiveDependents.push(current);
+
+      const importers = this.getImportersOf(currentId);
+      for (const imp of importers) {
+        if (!visited.has(imp.fromFileId)) queue.push(imp.fromFileId);
+      }
+    }
+
+    // Affected symbols in this file
+    const affectedSymbols = this.getSymbolsByFile(fileId).filter(s => s.exported);
+
+    // Risk level based on dependent count
+    const totalDeps = directDependents.length + transitiveDependents.length;
+    const riskLevel = totalDeps === 0 ? 'low'
+      : totalDeps <= 3 ? 'medium'
+      : totalDeps <= 10 ? 'high'
+      : 'critical';
+
+    return { file, directDependents, transitiveDependents, affectedSymbols, riskLevel };
+  }
+
+  getArchitecture(repoId: string): {
+    files: number;
+    symbols: number;
+    imports: number;
+    languages: Record<string, number>;
+    topLevelDirs: Array<{ dir: string; fileCount: number; languages: string[] }>;
+    mostImported: Array<{ path: string; importerCount: number }>;
+    mostExported: Array<{ path: string; exportCount: number }>;
+  } {
+    const index = this.getRepoIndex(repoId);
+    const files = this.getFilesByRepo(repoId);
+
+    // Top-level directory structure
+    const dirMap = new Map<string, { files: number; langs: Set<string> }>();
+    for (const f of files) {
+      const topDir = f.path.split('/')[0] || '.';
+      const entry = dirMap.get(topDir) || { files: 0, langs: new Set<string>() };
+      entry.files++;
+      entry.langs.add(f.language);
+      dirMap.set(topDir, entry);
+    }
+    const topLevelDirs = [...dirMap.entries()]
+      .map(([dir, data]) => ({ dir, fileCount: data.files, languages: [...data.langs] }))
+      .sort((a, b) => b.fileCount - a.fileCount);
+
+    // Most imported files
+    const importCounts = (this.db.prepare(`
+      SELECT to_file_id, COUNT(*) as cnt FROM imports
+      WHERE to_file_id IN (SELECT id FROM files WHERE repo_id = ?)
+      GROUP BY to_file_id ORDER BY cnt DESC LIMIT 10
+    `).all(repoId) as any[]);
+    const mostImported = importCounts.map(r => {
+      const file = this.getFile(r.to_file_id);
+      return { path: file?.path || r.to_file_id, importerCount: r.cnt };
+    });
+
+    // Most exported files
+    const exportCounts = (this.db.prepare(`
+      SELECT file_id, COUNT(*) as cnt FROM symbols
+      WHERE exported = 1 AND file_id IN (SELECT id FROM files WHERE repo_id = ?)
+      GROUP BY file_id ORDER BY cnt DESC LIMIT 10
+    `).all(repoId) as any[]);
+    const mostExported = exportCounts.map(r => {
+      const file = this.getFile(r.file_id);
+      return { path: file?.path || r.file_id, exportCount: r.cnt };
+    });
+
+    return {
+      files: index?.fileCount || files.length,
+      symbols: index?.symbolCount || 0,
+      imports: index?.importCount || 0,
+      languages: index?.languages || {},
+      topLevelDirs,
+      mostImported,
+      mostExported,
+    };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Codebase indexer — scans a repository, parses source files,
+ * and stores the knowledge graph in SQLite.
+ */
+
+export { GraphStore } from './graph/store.js';
+export type {
+  FileNode, SymbolNode, ImportEdge, ReferenceEdge,
+  RepoIndex, Language, SymbolKind, ReferenceKind,
+  SearchResult, DependencyResult, CallerResult, ImpactResult,
+} from './graph/schema.js';
+export { detectLanguage, isParseable, shouldIgnorePath } from './parsers/detect.js';
+export { indexRepository, indexFile } from './indexer.js';

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -1,0 +1,266 @@
+/**
+ * Main indexer — walks a repo directory, parses files, builds the graph.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { GraphStore } from './graph/store.js';
+import type { FileNode, SymbolNode, ImportEdge, Language, RepoIndex } from './graph/schema.js';
+import { detectLanguage, isParseable, shouldIgnorePath } from './parsers/detect.js';
+import { parseTypeScript } from './parsers/typescript-parser.js';
+import { parsePython } from './parsers/python-parser.js';
+import { parseGo } from './parsers/go-parser.js';
+
+interface IndexOptions {
+  repoId: string;
+  repoFullName: string;
+  repoPath: string;        // absolute path to cloned repo
+  commitHash?: string;
+  store: GraphStore;
+  /** Only re-index files whose hash changed (incremental) */
+  incremental?: boolean;
+  onProgress?: (msg: string) => void;
+}
+
+interface IndexResult {
+  fileCount: number;
+  symbolCount: number;
+  importCount: number;
+  languages: Record<string, number>;
+  durationMs: number;
+  errors: string[];
+}
+
+/**
+ * Index an entire repository.
+ */
+export async function indexRepository(opts: IndexOptions): Promise<IndexResult> {
+  const { repoId, repoFullName, repoPath, commitHash, store, incremental, onProgress } = opts;
+  const startTime = Date.now();
+  const errors: string[] = [];
+  const languages: Record<string, number> = {};
+  let fileCount = 0;
+  let symbolCount = 0;
+  let importCount = 0;
+
+  onProgress?.(`Indexing ${repoFullName} from ${repoPath}`);
+
+  // Walk the directory tree
+  const files = walkDirectory(repoPath);
+  onProgress?.(`Found ${files.length} files`);
+
+  // Get existing file hashes for incremental indexing
+  const existingFiles = incremental ? new Map(
+    store.getFilesByRepo(repoId).map(f => [f.path, f.hash])
+  ) : new Map();
+
+  // Track which files we've seen (for cleanup of deleted files)
+  const seenPaths = new Set<string>();
+
+  for (const absPath of files) {
+    const relPath = relative(repoPath, absPath);
+    if (shouldIgnorePath(relPath)) continue;
+
+    seenPaths.add(relPath);
+    const language = detectLanguage(relPath);
+    languages[language] = (languages[language] || 0) + 1;
+
+    try {
+      const content = readFileSync(absPath, 'utf-8');
+      const hash = createHash('sha256').update(content).digest('hex').slice(0, 16);
+
+      // Skip if unchanged (incremental)
+      if (incremental && existingFiles.get(relPath) === hash) continue;
+
+      const result = indexFile({
+        repoId, filePath: relPath, content, language, hash, store,
+      });
+
+      fileCount++;
+      symbolCount += result.symbols;
+      importCount += result.imports;
+    } catch (err: any) {
+      errors.push(`${relPath}: ${err.message}`);
+    }
+  }
+
+  // Clean up deleted files
+  if (incremental) {
+    const storedFiles = store.getFilesByRepo(repoId);
+    for (const f of storedFiles) {
+      if (!seenPaths.has(f.path)) {
+        store.deleteSymbolsByFile(f.id);
+        store.deleteImportsByFile(f.id);
+        // Delete the file itself
+        store.upsertFile({ ...f, size: 0, hash: 'deleted', lineCount: 0, indexedAt: new Date().toISOString() });
+      }
+    }
+  }
+
+  const durationMs = Date.now() - startTime;
+
+  // Update repo index metadata
+  store.upsertRepoIndex({
+    repoId,
+    fullName: repoFullName,
+    lastIndexedAt: new Date().toISOString(),
+    lastCommitHash: commitHash || '',
+    fileCount,
+    symbolCount,
+    importCount,
+    languages: languages as Record<Language, number>,
+    indexDurationMs: durationMs,
+  });
+
+  onProgress?.(`Indexed ${fileCount} files, ${symbolCount} symbols, ${importCount} imports in ${durationMs}ms`);
+
+  return { fileCount, symbolCount, importCount, languages, durationMs, errors };
+}
+
+/**
+ * Index a single file — parse and store its symbols + imports.
+ */
+export function indexFile(opts: {
+  repoId: string;
+  filePath: string;
+  content: string;
+  language: Language;
+  hash: string;
+  store: GraphStore;
+}): { symbols: number; imports: number } {
+  const { repoId, filePath, content, language, hash, store } = opts;
+  const fileId = `${repoId}:${filePath}`;
+  const now = new Date().toISOString();
+  const lineCount = content.split('\n').length;
+
+  // Store file node
+  const fileNode: FileNode = {
+    id: fileId,
+    repoId,
+    path: filePath,
+    language,
+    size: Buffer.byteLength(content),
+    hash,
+    lineCount,
+    indexedAt: now,
+  };
+  store.upsertFile(fileNode);
+
+  // Clear existing symbols + imports for this file (re-index)
+  store.deleteSymbolsByFile(fileId);
+  store.deleteImportsByFile(fileId);
+
+  // Parse if supported language
+  if (!isParseable(language)) return { symbols: 0, imports: 0 };
+
+  const parsed = parseSource(content, language, filePath);
+  let symbolCount = 0;
+  let importCount = 0;
+
+  // Store symbols
+  for (const sym of parsed.symbols) {
+    const symbolId = `${fileId}:${sym.name}:${sym.line}`;
+    const symbolNode: SymbolNode = {
+      id: symbolId,
+      fileId,
+      ...sym,
+    };
+    store.insertSymbol(symbolNode);
+    symbolCount++;
+  }
+
+  // Store imports
+  for (const imp of parsed.imports) {
+    const importId = `${fileId}:import:${imp.line}`;
+    const resolvedFileId = resolveImportPath(repoId, filePath, imp.toModule);
+    const importEdge: ImportEdge = {
+      id: importId,
+      fromFileId: fileId,
+      toFileId: resolvedFileId,
+      ...imp,
+    };
+    store.insertImport(importEdge);
+    importCount++;
+  }
+
+  return { symbols: symbolCount, imports: importCount };
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+function parseSource(
+  content: string,
+  language: Language,
+  filePath: string,
+): { symbols: Omit<SymbolNode, 'id' | 'fileId'>[]; imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[] } {
+  switch (language) {
+    case 'typescript':
+    case 'javascript':
+    case 'tsx':
+    case 'jsx':
+      return parseTypeScript(content, filePath);
+    case 'python':
+      return parsePython(content);
+    case 'go':
+      return parseGo(content);
+    default:
+      return { symbols: [], imports: [] };
+  }
+}
+
+/**
+ * Resolve a relative import path to a file ID.
+ * './utils' from 'src/index.ts' → 'repoId:src/utils.ts' (or .js, .tsx, etc.)
+ */
+function resolveImportPath(repoId: string, fromPath: string, importPath: string): string {
+  // Skip external packages
+  if (!importPath.startsWith('.') && !importPath.startsWith('/')) return '';
+
+  const fromDir = fromPath.substring(0, fromPath.lastIndexOf('/'));
+  const parts = importPath.split('/');
+  let resolved = fromDir;
+
+  for (const part of parts) {
+    if (part === '.') continue;
+    if (part === '..') {
+      resolved = resolved.substring(0, resolved.lastIndexOf('/'));
+    } else {
+      resolved = resolved ? `${resolved}/${part}` : part;
+    }
+  }
+
+  // Try common extensions
+  const extensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go'];
+  for (const ext of extensions) {
+    const candidate = `${repoId}:${resolved}${ext}`;
+    return candidate; // Return first candidate — store will resolve
+  }
+  return `${repoId}:${resolved}`;
+}
+
+/**
+ * Walk a directory tree and return all file paths.
+ */
+function walkDirectory(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(currentDir: string): void {
+    try {
+      const entries = readdirSync(currentDir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          if (!shouldIgnorePath(entry.name + '/')) {
+            walk(fullPath);
+          }
+        } else if (entry.isFile()) {
+          results.push(fullPath);
+        }
+      }
+    } catch { /* permission error or similar */ }
+  }
+
+  walk(dir);
+  return results;
+}

--- a/packages/indexer/src/parsers/detect.ts
+++ b/packages/indexer/src/parsers/detect.ts
@@ -1,0 +1,68 @@
+/**
+ * Language detection from file extensions.
+ */
+
+import type { Language } from '../graph/schema.js';
+
+const EXTENSION_MAP: Record<string, Language> = {
+  '.ts': 'typescript',
+  '.tsx': 'tsx',
+  '.js': 'javascript',
+  '.jsx': 'jsx',
+  '.mjs': 'javascript',
+  '.cjs': 'javascript',
+  '.py': 'python',
+  '.go': 'go',
+  '.rs': 'rust',
+  '.java': 'java',
+  '.tf': 'terraform',
+  '.hcl': 'terraform',
+  '.sql': 'sql',
+  '.css': 'css',
+  '.scss': 'css',
+  '.html': 'html',
+  '.json': 'json',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.md': 'markdown',
+  '.mdx': 'markdown',
+};
+
+const PARSEABLE_LANGUAGES: Set<Language> = new Set([
+  'typescript', 'tsx', 'javascript', 'jsx',
+  'python', 'go', 'rust', 'java', 'terraform',
+]);
+
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', '.next',
+  '__pycache__', '.pytest_cache', 'venv', '.venv',
+  'target', 'vendor', '.terraform',
+  'coverage', '.nyc_output', '.cache',
+]);
+
+const IGNORE_FILES = new Set([
+  'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
+  '.DS_Store', 'thumbs.db',
+]);
+
+export function detectLanguage(filePath: string): Language {
+  const ext = filePath.slice(filePath.lastIndexOf('.'));
+  return EXTENSION_MAP[ext] || 'unknown';
+}
+
+export function isParseable(language: Language): boolean {
+  return PARSEABLE_LANGUAGES.has(language);
+}
+
+export function shouldIgnorePath(path: string): boolean {
+  const parts = path.split('/');
+  // Check each directory component
+  for (const part of parts.slice(0, -1)) {
+    if (IGNORE_DIRS.has(part)) return true;
+  }
+  // Check filename
+  const filename = parts[parts.length - 1];
+  if (IGNORE_FILES.has(filename)) return true;
+  if (filename.startsWith('.')) return true;
+  return false;
+}

--- a/packages/indexer/src/parsers/go-parser.ts
+++ b/packages/indexer/src/parsers/go-parser.ts
@@ -1,0 +1,109 @@
+/**
+ * Go parser — extracts functions, types, structs, imports.
+ */
+
+import type { SymbolNode, ImportEdge } from '../graph/schema.js';
+
+export interface ParseResult {
+  symbols: Omit<SymbolNode, 'id' | 'fileId'>[];
+  imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[];
+}
+
+export function parseGo(source: string): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+  const lines = source.split('\n');
+  let inImportBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+    const trimmed = line.trim();
+
+    // import block
+    if (trimmed === 'import (') { inImportBlock = true; continue; }
+    if (inImportBlock && trimmed === ')') { inImportBlock = false; continue; }
+    if (inImportBlock) {
+      const pkg = trimmed.replace(/^"/, '').replace(/"$/, '').replace(/^\w+\s+"/, '').replace(/"$/, '');
+      if (pkg) {
+        imports.push({
+          toModule: pkg,
+          symbols: [pkg.split('/').pop()!],
+          isDefault: true,
+          isNamespace: false,
+          line: lineNum,
+        });
+      }
+      continue;
+    }
+
+    // Single import
+    const singleImport = trimmed.match(/^import\s+(?:(\w+)\s+)?"([^"]+)"/);
+    if (singleImport) {
+      imports.push({
+        toModule: singleImport[2],
+        symbols: [singleImport[1] || singleImport[2].split('/').pop()!],
+        isDefault: true,
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // func Name(params) returnType
+    const funcMatch = trimmed.match(/^func\s+(?:\((\w+)\s+\*?(\w+)\)\s+)?(\w+)\s*\(([^)]*)\)(?:\s*(?:\(([^)]+)\)|(\w+)))?/);
+    if (funcMatch) {
+      const isMethod = !!funcMatch[1];
+      const name = funcMatch[3];
+      const exported = name[0] === name[0].toUpperCase();
+      symbols.push({
+        name,
+        kind: isMethod ? 'method' : 'function',
+        line: lineNum,
+        signature: trimmed.replace(/\s*\{.*$/, ''),
+        exported,
+      });
+      continue;
+    }
+
+    // type Name struct { ... }
+    const structMatch = trimmed.match(/^type\s+(\w+)\s+struct\b/);
+    if (structMatch) {
+      symbols.push({
+        name: structMatch[1],
+        kind: 'struct',
+        line: lineNum,
+        signature: `type ${structMatch[1]} struct`,
+        exported: structMatch[1][0] === structMatch[1][0].toUpperCase(),
+      });
+      continue;
+    }
+
+    // type Name interface { ... }
+    const ifaceMatch = trimmed.match(/^type\s+(\w+)\s+interface\b/);
+    if (ifaceMatch) {
+      symbols.push({
+        name: ifaceMatch[1],
+        kind: 'interface',
+        line: lineNum,
+        signature: `type ${ifaceMatch[1]} interface`,
+        exported: ifaceMatch[1][0] === ifaceMatch[1][0].toUpperCase(),
+      });
+      continue;
+    }
+
+    // type Name = ... (type alias)
+    const typeMatch = trimmed.match(/^type\s+(\w+)\s+(?!struct|interface)\w/);
+    if (typeMatch) {
+      symbols.push({
+        name: typeMatch[1],
+        kind: 'type',
+        line: lineNum,
+        exported: typeMatch[1][0] === typeMatch[1][0].toUpperCase(),
+      });
+      continue;
+    }
+  }
+
+  return { symbols, imports };
+}

--- a/packages/indexer/src/parsers/index.ts
+++ b/packages/indexer/src/parsers/index.ts
@@ -1,0 +1,4 @@
+export { detectLanguage, isParseable, shouldIgnorePath } from './detect.js';
+export { parseTypeScript } from './typescript-parser.js';
+export { parsePython } from './python-parser.js';
+export { parseGo } from './go-parser.js';

--- a/packages/indexer/src/parsers/python-parser.ts
+++ b/packages/indexer/src/parsers/python-parser.ts
@@ -1,0 +1,78 @@
+/**
+ * Python parser — extracts functions, classes, imports.
+ */
+
+import type { SymbolNode, ImportEdge } from '../graph/schema.js';
+
+export interface ParseResult {
+  symbols: Omit<SymbolNode, 'id' | 'fileId'>[];
+  imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[];
+}
+
+export function parsePython(source: string): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+  const lines = source.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+    const trimmed = line.trim();
+
+    // import module
+    const importMatch = trimmed.match(/^import\s+([\w.]+)(?:\s+as\s+(\w+))?/);
+    if (importMatch) {
+      imports.push({
+        toModule: importMatch[1],
+        symbols: [importMatch[2] || importMatch[1].split('.').pop()!],
+        isDefault: true,
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // from module import X, Y
+    const fromImport = trimmed.match(/^from\s+([\w.]+)\s+import\s+(.+)/);
+    if (fromImport) {
+      const syms = fromImport[2].split(',').map(s => s.trim().split(/\s+as\s+/)[0].trim()).filter(Boolean);
+      imports.push({
+        toModule: fromImport[1],
+        symbols: syms,
+        isDefault: false,
+        isNamespace: syms.includes('*'),
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // def function_name(params):
+    const defMatch = trimmed.match(/^(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*([^:]+))?:/);
+    if (defMatch) {
+      const indent = line.length - line.trimStart().length;
+      symbols.push({
+        name: defMatch[1],
+        kind: indent > 0 ? 'method' : 'function',
+        line: lineNum,
+        signature: `def ${defMatch[1]}(${defMatch[2]})${defMatch[3] ? ` -> ${defMatch[3].trim()}` : ''}`,
+        exported: !defMatch[1].startsWith('_'),
+      });
+      continue;
+    }
+
+    // class ClassName(Base):
+    const classMatch = trimmed.match(/^class\s+(\w+)(?:\(([^)]*)\))?:/);
+    if (classMatch) {
+      symbols.push({
+        name: classMatch[1],
+        kind: 'class',
+        line: lineNum,
+        signature: `class ${classMatch[1]}${classMatch[2] ? `(${classMatch[2]})` : ''}`,
+        exported: !classMatch[1].startsWith('_'),
+      });
+      continue;
+    }
+  }
+
+  return { symbols, imports };
+}

--- a/packages/indexer/src/parsers/typescript-parser.ts
+++ b/packages/indexer/src/parsers/typescript-parser.ts
@@ -1,0 +1,223 @@
+/**
+ * TypeScript/JavaScript parser using tree-sitter.
+ * Extracts symbols (functions, classes, types, interfaces) and imports.
+ */
+
+import type { SymbolNode, ImportEdge, SymbolKind } from '../graph/schema.js';
+
+export interface ParseResult {
+  symbols: Omit<SymbolNode, 'id' | 'fileId'>[];
+  imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[];
+}
+
+/**
+ * Parse TypeScript/JavaScript source code and extract symbols + imports.
+ * Uses tree-sitter for accurate AST-based extraction.
+ *
+ * Falls back to regex-based extraction if tree-sitter is not available.
+ */
+export function parseTypeScript(source: string, _filePath?: string): ParseResult {
+  // Use regex-based extraction (tree-sitter integration is a follow-up —
+  // native bindings require compilation which may not work in all environments)
+  return parseWithRegex(source);
+}
+
+/**
+ * Regex-based parser for TypeScript/JavaScript.
+ * Handles the most common patterns. Not as accurate as tree-sitter AST
+ * but works everywhere without native dependencies.
+ */
+function parseWithRegex(source: string): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+  const lines = source.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+    const trimmed = line.trim();
+
+    // ── Imports ─────────────────────────────────────────────────────
+
+    // import { X, Y } from 'module'
+    const namedImport = trimmed.match(/^import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/);
+    if (namedImport) {
+      const symbols = namedImport[1].split(',').map(s => s.trim().split(/\s+as\s+/)[0].trim()).filter(Boolean);
+      imports.push({
+        toModule: namedImport[2],
+        symbols,
+        isDefault: false,
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // import X from 'module'
+    const defaultImport = trimmed.match(/^import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+    if (defaultImport) {
+      imports.push({
+        toModule: defaultImport[2],
+        symbols: [defaultImport[1]],
+        isDefault: true,
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // import * as X from 'module'
+    const nsImport = trimmed.match(/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+    if (nsImport) {
+      imports.push({
+        toModule: nsImport[2],
+        symbols: [nsImport[1]],
+        isDefault: false,
+        isNamespace: true,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // import type { X } from 'module' (TypeScript)
+    const typeImport = trimmed.match(/^import\s+type\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/);
+    if (typeImport) {
+      const symbols = typeImport[1].split(',').map(s => s.trim().split(/\s+as\s+/)[0].trim()).filter(Boolean);
+      imports.push({
+        toModule: typeImport[2],
+        symbols,
+        isDefault: false,
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // require('module')
+    const requireMatch = trimmed.match(/(?:const|let|var)\s+(?:\{([^}]+)\}|(\w+))\s*=\s*require\s*\(['"]([^'"]+)['"]\)/);
+    if (requireMatch) {
+      const syms = requireMatch[1]
+        ? requireMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+        : [requireMatch[2]];
+      imports.push({
+        toModule: requireMatch[3],
+        symbols: syms,
+        isDefault: !requireMatch[1],
+        isNamespace: false,
+        line: lineNum,
+      });
+      continue;
+    }
+
+    // ── Symbols ─────────────────────────────────────────────────────
+
+    const isExported = trimmed.startsWith('export ');
+    const isDefault = trimmed.includes('export default ');
+    const cleaned = trimmed.replace(/^export\s+(default\s+)?/, '');
+
+    // function name(params): returnType
+    const funcMatch = cleaned.match(/^(?:async\s+)?function\s+(\w+)\s*(\([^)]*\)(?:\s*:\s*[^{]+)?)/);
+    if (funcMatch) {
+      symbols.push({
+        name: funcMatch[1],
+        kind: 'function',
+        line: lineNum,
+        signature: `function ${funcMatch[1]}${funcMatch[2]}`,
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // const name = (params) => ... (arrow function)
+    const arrowMatch = cleaned.match(/^(?:const|let|var)\s+(\w+)\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?(\([^)]*\)(?:\s*:\s*[^=]+)?)\s*=>/);
+    if (arrowMatch) {
+      symbols.push({
+        name: arrowMatch[1],
+        kind: 'function',
+        line: lineNum,
+        signature: `const ${arrowMatch[1]} = ${arrowMatch[2]} =>`,
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // class Name { ... }
+    const classMatch = cleaned.match(/^(?:abstract\s+)?class\s+(\w+)(?:\s+extends\s+(\w+))?(?:\s+implements\s+([^{]+))?/);
+    if (classMatch) {
+      symbols.push({
+        name: classMatch[1],
+        kind: 'class',
+        line: lineNum,
+        signature: classMatch[0].trim(),
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // interface Name { ... }
+    const ifaceMatch = cleaned.match(/^interface\s+(\w+)(?:\s+extends\s+([^{]+))?/);
+    if (ifaceMatch) {
+      symbols.push({
+        name: ifaceMatch[1],
+        kind: 'interface',
+        line: lineNum,
+        signature: ifaceMatch[0].trim(),
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // type Name = ...
+    const typeMatch = cleaned.match(/^type\s+(\w+)(?:<[^>]+>)?\s*=/);
+    if (typeMatch) {
+      symbols.push({
+        name: typeMatch[1],
+        kind: 'type',
+        line: lineNum,
+        signature: `type ${typeMatch[1]}`,
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // enum Name { ... }
+    const enumMatch = cleaned.match(/^(?:const\s+)?enum\s+(\w+)/);
+    if (enumMatch) {
+      symbols.push({
+        name: enumMatch[1],
+        kind: 'enum',
+        line: lineNum,
+        signature: `enum ${enumMatch[1]}`,
+        exported: isExported,
+      });
+      continue;
+    }
+
+    // const NAME = ... (constants, exported)
+    if (isExported) {
+      const constMatch = cleaned.match(/^const\s+(\w+)\s*(?::\s*[^=]+)?\s*=/);
+      if (constMatch && constMatch[1] === constMatch[1].toUpperCase()) {
+        symbols.push({
+          name: constMatch[1],
+          kind: 'constant',
+          line: lineNum,
+          exported: true,
+        });
+        continue;
+      }
+
+      // export const name = ... (non-constant exported variable)
+      if (constMatch) {
+        symbols.push({
+          name: constMatch[1],
+          kind: 'variable',
+          line: lineNum,
+          exported: true,
+        });
+        continue;
+      }
+    }
+  }
+
+  return { symbols, imports };
+}

--- a/packages/indexer/src/tools/definitions.ts
+++ b/packages/indexer/src/tools/definitions.ts
@@ -1,0 +1,102 @@
+/**
+ * Tool definitions for codebase intelligence.
+ * These are registered as Armada tools via registerToolDef.
+ */
+
+export const CODEBASE_TOOLS = [
+  {
+    name: 'armada_code_search',
+    description: 'Search for files and symbols across indexed repositories. Returns matching files and function/class/type definitions.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/search',
+    parameters: [
+      { name: 'query', type: 'string', description: 'Search query — matches file paths and symbol names', required: true },
+      { name: 'repo', type: 'string', description: 'Repository full name to search in (e.g. coderage-labs/demo-backend). Omit to search all repos.' },
+      { name: 'kind', type: 'string', description: 'Filter by symbol kind: function, class, interface, type, method, struct, enum' },
+    ],
+  },
+  {
+    name: 'armada_code_dependencies',
+    description: 'Get the dependency graph for a file — what it imports and what imports it.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/dependencies',
+    parameters: [
+      { name: 'file', type: 'string', description: 'File path within the repo (e.g. src/routes/auth.ts)', required: true },
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+    ],
+  },
+  {
+    name: 'armada_code_callers',
+    description: 'Find all callers of a function/symbol and what it calls.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/callers',
+    parameters: [
+      { name: 'symbol', type: 'string', description: 'Symbol name to look up (function, class, etc.)', required: true },
+      { name: 'repo', type: 'string', description: 'Repository full name. Omit to search all repos.' },
+    ],
+  },
+  {
+    name: 'armada_code_impact',
+    description: 'Analyse the impact of changing a file — direct and transitive dependents, affected exports, risk level.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/impact',
+    parameters: [
+      { name: 'file', type: 'string', description: 'File path within the repo', required: true },
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+    ],
+  },
+  {
+    name: 'armada_code_architecture',
+    description: 'Get a high-level architectural overview of a repository — directory structure, languages, most-imported files, export hubs.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/architecture',
+    parameters: [
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+    ],
+  },
+  {
+    name: 'armada_code_file_context',
+    description: 'Get full context for a file — its symbols, imports, who imports it, and related files.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/file-context',
+    parameters: [
+      { name: 'file', type: 'string', description: 'File path within the repo', required: true },
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+    ],
+  },
+  {
+    name: 'armada_code_index',
+    description: 'Trigger indexing (or re-indexing) of a repository. Returns index stats.',
+    category: 'codebase',
+    scope: 'projects:write',
+    method: 'POST' as const,
+    path: '/api/codebase/index',
+    parameters: [
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+      { name: 'force', type: 'boolean', description: 'Force full re-index (ignore incremental cache)' },
+    ],
+  },
+  {
+    name: 'armada_code_index_status',
+    description: 'Check the indexing status of a repository — when it was last indexed, file/symbol counts, languages.',
+    category: 'codebase',
+    scope: 'projects:read',
+    method: 'POST' as const,
+    path: '/api/codebase/index-status',
+    parameters: [
+      { name: 'repo', type: 'string', description: 'Repository full name', required: true },
+    ],
+  },
+];

--- a/packages/indexer/src/tools/index.ts
+++ b/packages/indexer/src/tools/index.ts
@@ -1,0 +1,1 @@
+export { CODEBASE_TOOLS } from './definitions.js';

--- a/packages/indexer/tsconfig.json
+++ b/packages/indexer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Closes #179 (Phase 1 + Phase 2)

### New package: @coderage-labs/armada-indexer (2018 lines)

**Graph schema**: files, symbols, imports, references — language-agnostic
**SQLite store**: full CRUD + search, dependency graph, caller analysis, impact analysis, architecture overview
**Parsers**: TypeScript/JavaScript, Python, Go (regex-based, tree-sitter upgrade later)
**Indexer**: walks repo directory, parses all files, stores in graph. Incremental via content hash.

### 8 new Armada tools (category: codebase)
- `armada_code_search` — search files and symbols
- `armada_code_dependencies` — import/importer graph for a file
- `armada_code_callers` — who calls a symbol, what it calls
- `armada_code_impact` — change impact analysis with risk level
- `armada_code_architecture` — repo structure overview
- `armada_code_file_context` — full context for a file
- `armada_code_index` — trigger indexing
- `armada_code_index_status` — check index freshness

### What's NOT in this PR (future phases)
- Remote MCP server for external tools (Phase 3)
- Auto-index on repo link / webhook (Phase 4)
- Tree-sitter upgrade for more accurate parsing
- Rust, Java, Terraform parsers
- Robin control plugin integration

0 TS errors, 163 tests pass.