### PR TITLE
feat(ui): Codebase visualiser page (#181)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2643,6 +2643,42 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
@@ -3389,7 +3425,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
@@ -3531,6 +3572,103 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -3714,6 +3852,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -3915,6 +4059,38 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.75",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -4510,6 +4686,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4727,6 +4909,193 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "license": "MIT",
@@ -4741,6 +5110,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5529,6 +5904,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -6565,6 +6950,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6576,6 +6971,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -7901,6 +8305,36 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "dev": true,
@@ -8050,6 +8484,51 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8058,6 +8537,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8813,6 +9298,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9168,6 +9659,28 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -10028,6 +10541,34 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "packages/control": {
       "name": "@coderage-labs/armada-control",
       "version": "0.3.0",
@@ -10872,6 +11413,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@simplewebauthn/browser": "^11.0.0",
         "@tanstack/react-query": "^5.90.21",
+        "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "emoji-picker-react": "^4.18.0",
@@ -10882,6 +11424,7 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^16.5.8",
         "react-router-dom": "^7.13.1",
+        "recharts": "^3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "vaul": "^1.1.2"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@simplewebauthn/browser": "^11.0.0",
     "@tanstack/react-query": "^5.90.21",
+    "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "emoji-picker-react": "^4.18.0",
@@ -31,6 +32,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^16.5.8",
     "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "vaul": "^1.1.2"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -60,6 +60,7 @@ function AnimatedRoutes() {
             <Route path="/plugins" element={<Plugins />} />
             <Route path="/models" element={<Models />} />
             <Route path="/providers" element={<Providers />} />
+            <Route path="/codebase" element={<Codebase />} />
             <Route path="/logs" element={<Logs />} />
             <Route path="/settings" element={<Settings />} />
         </Routes>
@@ -102,6 +103,7 @@ import SetupWizard from './pages/SetupWizard';
 import Settings from './pages/Settings';
 import Usage from './pages/Usage';
 import Notifications from './pages/Notifications';
+import Codebase from './pages/Codebase';
 import { ChangesetBottomBar } from './components/ChangesetBottomBar';
 import { Toaster } from './components/ui/sonner';
 

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Home, Monitor, Bot, Cpu, Rocket, FileCode, FolderKanban, GitBranch,
   Activity, Bell, BellRing, Puzzle, Plug, Terminal, Menu, X, LogOut, Bolt, Users,
   Workflow, Radio, Cable, Layers, Settings, Shield, Server, GitPullRequest,
-  Wifi, WifiOff, TrendingUp,
+  Wifi, WifiOff, TrendingUp, Code2,
 } from 'lucide-react';
 
 interface BadgeCounts {
@@ -39,6 +39,7 @@ const navItems: NavItem[] = [
   { to: '/models', label: 'Models', icon: Cpu },
   { to: '/projects', label: 'Projects', icon: FolderKanban },
   { to: '/workflows', label: 'Workflows', icon: Workflow },
+  { to: '/codebase', label: 'Codebase', icon: Code2 },
   { to: '/users', label: 'Users', icon: Users, requiredScope: 'users:write' },
   { to: '/hierarchy', label: 'Hierarchy', icon: GitBranch },
   { to: '/activity', label: 'Activity', icon: Activity },

--- a/packages/ui/src/pages/Codebase.tsx
+++ b/packages/ui/src/pages/Codebase.tsx
@@ -1,0 +1,840 @@
+import { useCallback, useEffect, useState, useMemo } from 'react';
+import { Search, RefreshCw, Database, Loader2, AlertCircle, Code2, FileCode, GitBranch } from 'lucide-react';
+import { apiFetch } from '../hooks/useApi';
+import { PageHeader } from '../components/PageHeader';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Badge } from '../components/ui/badge';
+import { toast } from 'sonner';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  Node,
+  Edge,
+  useNodesState,
+  useEdgesState,
+  ConnectionLineType,
+  Panel,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+
+/* ── Types ─────────────────────────────────────────── */
+
+interface SymbolResult {
+  file: string;
+  name: string;
+  kind: 'function' | 'class' | 'interface' | 'type' | 'const' | 'let' | 'var' | 'method';
+  line: number;
+}
+
+interface FileResult {
+  file: string;
+  language: string;
+}
+
+interface SearchResponse {
+  files: FileResult[];
+  symbols: SymbolResult[];
+}
+
+interface DependencyResponse {
+  file: string;
+  imports: string[];
+  importedBy: string[];
+}
+
+interface ArchitectureResponse {
+  files: number;
+  symbols: number;
+  imports: number;
+  languages: Record<string, number>;
+  topLevelDirs: string[];
+  mostImported: Array<{ file: string; count: number }>;
+}
+
+interface IndexStatusResponse {
+  indexed: boolean;
+  lastIndexedAt?: string;
+  fileCount?: number;
+  symbolCount?: number;
+  importCount?: number;
+  languages?: Record<string, number>;
+}
+
+interface IndexResponse {
+  fileCount: number;
+  symbolCount: number;
+  importCount: number;
+  languages: Record<string, number>;
+  durationMs: number;
+  errors: string[];
+}
+
+interface FileContextResponse {
+  file: string;
+  symbols: SymbolResult[];
+  imports: string[];
+  importedBy: string[];
+}
+
+/* ── Helpers ───────────────────────────────────────── */
+
+function getLanguageColor(language: string): string {
+  const lang = language.toLowerCase();
+  if (lang.includes('typescript') || lang.includes('ts')) return '#3178c6';
+  if (lang.includes('javascript') || lang.includes('js')) return '#f7df1e';
+  if (lang.includes('python') || lang.includes('py')) return '#22c55e';
+  if (lang.includes('go')) return '#00add8';
+  if (lang.includes('rust')) return '#ce422b';
+  if (lang.includes('json')) return '#eab308';
+  if (lang.includes('markdown') || lang.includes('md')) return '#a855f7';
+  return '#6b7280';
+}
+
+function getKindBadgeColor(kind: string): string {
+  switch (kind) {
+    case 'function':
+    case 'method':
+      return 'bg-blue-500/20 border-blue-500/30 text-blue-300';
+    case 'class':
+      return 'bg-violet-500/20 border-violet-500/30 text-violet-300';
+    case 'interface':
+    case 'type':
+      return 'bg-cyan-500/20 border-cyan-500/30 text-cyan-300';
+    case 'const':
+    case 'let':
+    case 'var':
+      return 'bg-amber-500/20 border-amber-500/30 text-amber-300';
+    default:
+      return 'bg-zinc-500/20 border-zinc-500/30 text-zinc-300';
+  }
+}
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/* ── Graph View ────────────────────────────────────── */
+
+interface GraphViewProps {
+  repo?: string;
+  onFileSelect: (file: string) => void;
+}
+
+function GraphView({ repo, onFileSelect }: GraphViewProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadGraph();
+  }, [repo]);
+
+  async function loadGraph() {
+    setLoading(true);
+    try {
+      const arch = await apiFetch<ArchitectureResponse>('/api/codebase/architecture', {
+        method: 'POST',
+        body: JSON.stringify({ repo: repo || undefined }),
+      });
+
+      // Use mostImported files as nodes
+      const topFiles = arch.mostImported.slice(0, 50); // Limit to 50 nodes for performance
+
+      const nodeMap = new Map<string, { x: number; y: number; language: string }>();
+      const newNodes: Node[] = [];
+      const newEdges: Edge[] = [];
+
+      // Create nodes in a circular layout
+      const radius = 300;
+      const angleStep = (2 * Math.PI) / topFiles.length;
+
+      topFiles.forEach((item, idx) => {
+        const angle = idx * angleStep;
+        const x = 500 + radius * Math.cos(angle);
+        const y = 400 + radius * Math.sin(angle);
+
+        // Infer language from file extension
+        const ext = item.file.split('.').pop() || '';
+        let language = 'other';
+        if (['ts', 'tsx'].includes(ext)) language = 'typescript';
+        else if (['js', 'jsx'].includes(ext)) language = 'javascript';
+        else if (ext === 'py') language = 'python';
+        else if (ext === 'go') language = 'go';
+        else if (ext === 'json') language = 'json';
+        else if (ext === 'md') language = 'markdown';
+
+        nodeMap.set(item.file, { x, y, language });
+
+        newNodes.push({
+          id: item.file,
+          type: 'default',
+          position: { x, y },
+          data: {
+            label: item.file.split('/').pop() || item.file,
+          },
+          style: {
+            background: getLanguageColor(language),
+            color: '#fff',
+            border: '2px solid #fff',
+            fontSize: 11,
+            padding: '6px 10px',
+            borderRadius: 8,
+          },
+        });
+      });
+
+      // Fetch dependencies for each file and create edges
+      for (const item of topFiles) {
+        try {
+          const deps = await apiFetch<DependencyResponse>('/api/codebase/dependencies', {
+            method: 'POST',
+            body: JSON.stringify({ file: item.file, repo: repo || undefined }),
+          });
+
+          deps.imports.forEach((imp) => {
+            if (nodeMap.has(imp)) {
+              newEdges.push({
+                id: `${item.file}-${imp}`,
+                source: item.file,
+                target: imp,
+                type: ConnectionLineType.Bezier,
+                style: { stroke: '#6b7280', strokeWidth: 1 },
+                animated: false,
+              });
+            }
+          });
+        } catch {
+          // Skip files with no dependencies
+        }
+      }
+
+      setNodes(newNodes);
+      setEdges(newEdges);
+    } catch (err: any) {
+      toast.error(`Failed to load graph: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleNodeClick(event: React.MouseEvent, node: Node) {
+    setSelectedFile(node.id);
+    onFileSelect(node.id);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+        <span className="ml-2 text-sm text-zinc-500">Loading dependency graph...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 overflow-hidden" style={{ height: '600px' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={handleNodeClick}
+        fitView
+        className="bg-zinc-950"
+      >
+        <Background color="#27272a" gap={16} />
+        <Controls className="bg-zinc-800 border border-zinc-700" />
+        <MiniMap className="bg-zinc-900 border border-zinc-700" nodeColor={(n) => n.style?.background as string || '#6b7280'} />
+        <Panel position="top-left" className="bg-zinc-800/90 backdrop-blur border border-zinc-700 rounded-lg p-3 text-xs text-zinc-300">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('typescript') }} />
+              <span>TypeScript</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('javascript') }} />
+              <span>JavaScript</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('python') }} />
+              <span>Python</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('go') }} />
+              <span>Go</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('json') }} />
+              <span>JSON</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full" style={{ background: getLanguageColor('other') }} />
+              <span>Other</span>
+            </div>
+          </div>
+        </Panel>
+      </ReactFlow>
+    </div>
+  );
+}
+
+/* ── Architecture Overview ─────────────────────────── */
+
+interface ArchitectureOverviewProps {
+  repo?: string;
+}
+
+function ArchitectureOverview({ repo }: ArchitectureOverviewProps) {
+  const [arch, setArch] = useState<ArchitectureResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadArchitecture();
+  }, [repo]);
+
+  async function loadArchitecture() {
+    setLoading(true);
+    try {
+      const data = await apiFetch<ArchitectureResponse>('/api/codebase/architecture', {
+        method: 'POST',
+        body: JSON.stringify({ repo: repo || undefined }),
+      });
+      setArch(data);
+    } catch (err: any) {
+      toast.error(`Failed to load architecture: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (loading || !arch) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+      </div>
+    );
+  }
+
+  const languageData = Object.entries(arch.languages).map(([lang, count]) => ({
+    name: lang,
+    value: count,
+    color: getLanguageColor(lang),
+  }));
+
+  return (
+    <div className="space-y-6">
+      {/* Stats cards */}
+      <div className="grid grid-cols-3 gap-4">
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3">
+          <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Files</div>
+          <div className="text-2xl font-bold text-zinc-100 mt-1">{arch.files.toLocaleString()}</div>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3">
+          <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Symbols</div>
+          <div className="text-2xl font-bold text-violet-300 mt-1">{arch.symbols.toLocaleString()}</div>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3">
+          <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Imports</div>
+          <div className="text-2xl font-bold text-blue-300 mt-1">{arch.imports.toLocaleString()}</div>
+        </div>
+      </div>
+
+      {/* Language distribution */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <h3 className="text-sm font-semibold text-zinc-300 mb-4">Language Distribution</h3>
+          {languageData.length === 0 ? (
+            <p className="text-sm text-zinc-600">No language data available</p>
+          ) : (
+            <ResponsiveContainer width="100%" height={200}>
+              <PieChart>
+                <Pie
+                  data={languageData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={({ name, percent }) => `${name} ${((percent || 0) * 100).toFixed(0)}%`}
+                  outerRadius={80}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {languageData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <RechartsTooltip
+                  contentStyle={{
+                    backgroundColor: '#18181b',
+                    border: '1px solid #3f3f46',
+                    borderRadius: '8px',
+                    fontSize: '12px',
+                    color: '#e4e4e7',
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* Most imported files */}
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <h3 className="text-sm font-semibold text-zinc-300 mb-3">Most Imported Files</h3>
+          {arch.mostImported.length === 0 ? (
+            <p className="text-sm text-zinc-600">No import data available</p>
+          ) : (
+            <div className="space-y-2">
+              {arch.mostImported.slice(0, 10).map((item, idx) => (
+                <div key={item.file} className="flex items-center justify-between py-2 px-3 rounded-lg bg-zinc-800/50 hover:bg-zinc-800 transition-colors">
+                  <span className="text-xs text-zinc-300 truncate flex-1 font-mono">{item.file.split('/').pop()}</span>
+                  <Badge variant="secondary" className="ml-2 shrink-0 bg-violet-500/20 text-violet-300 text-[10px]">
+                    {item.count}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Symbol Search ─────────────────────────────────── */
+
+interface SymbolSearchProps {
+  repo?: string;
+  onFileSelect: (file: string) => void;
+}
+
+function SymbolSearch({ repo, onFileSelect }: SymbolSearchProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResponse | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  async function handleSearch() {
+    if (!query.trim()) return;
+    setSearching(true);
+    try {
+      const data = await apiFetch<SearchResponse>('/api/codebase/search', {
+        method: 'POST',
+        body: JSON.stringify({ query, repo: repo || undefined }),
+      });
+      setResults(data);
+    } catch (err: any) {
+      toast.error(`Search failed: ${err.message}`);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Search input */}
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-600" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            placeholder="Search symbols, files..."
+            className="pl-9 pr-3 py-2 rounded-lg bg-zinc-800/50 border border-zinc-800 text-sm text-zinc-200 focus:outline-none focus:border-violet-500/50"
+          />
+        </div>
+        <Button
+          onClick={handleSearch}
+          disabled={searching || !query.trim()}
+          className="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium disabled:opacity-40"
+        >
+          {searching ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Search'}
+        </Button>
+      </div>
+
+      {/* Results */}
+      {results && (
+        <div className="space-y-4">
+          {/* Symbols */}
+          {results.symbols.length > 0 && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+              <h3 className="text-sm font-semibold text-zinc-300 mb-3">
+                Symbols ({results.symbols.length})
+              </h3>
+              <div className="space-y-2">
+                {results.symbols.map((sym, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-between py-2 px-3 rounded-lg bg-zinc-800/50 hover:bg-zinc-800 transition-colors cursor-pointer"
+                    onClick={() => onFileSelect(sym.file)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary" className={`text-[10px] px-2 py-0.5 ${getKindBadgeColor(sym.kind)}`}>
+                        {sym.kind}
+                      </Badge>
+                      <span className="text-sm font-medium text-zinc-200">{sym.name}</span>
+                      <span className="text-xs text-zinc-600">@{sym.line}</span>
+                    </div>
+                    <span className="text-xs text-zinc-500 font-mono truncate max-w-md">{sym.file}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Files */}
+          {results.files.length > 0 && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+              <h3 className="text-sm font-semibold text-zinc-300 mb-3">
+                Files ({results.files.length})
+              </h3>
+              <div className="space-y-2">
+                {results.files.map((file, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-between py-2 px-3 rounded-lg bg-zinc-800/50 hover:bg-zinc-800 transition-colors cursor-pointer"
+                    onClick={() => onFileSelect(file.file)}
+                  >
+                    <span className="text-sm text-zinc-300 font-mono truncate flex-1">{file.file}</span>
+                    <Badge variant="secondary" className="ml-2 shrink-0 text-[10px]" style={{ backgroundColor: getLanguageColor(file.language) }}>
+                      {file.language}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {results.symbols.length === 0 && results.files.length === 0 && (
+            <div className="text-center py-12 text-sm text-zinc-500">
+              No results found for "{query}"
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Index Status ──────────────────────────────────── */
+
+interface IndexStatusProps {
+  repo?: string;
+  onReindex: () => void;
+}
+
+function IndexStatus({ repo, onReindex }: IndexStatusProps) {
+  const [status, setStatus] = useState<IndexStatusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [indexing, setIndexing] = useState(false);
+
+  useEffect(() => {
+    loadStatus();
+  }, [repo]);
+
+  async function loadStatus() {
+    setLoading(true);
+    try {
+      const data = await apiFetch<IndexStatusResponse>('/api/codebase/index-status', {
+        method: 'POST',
+        body: JSON.stringify({ repo: repo || undefined }),
+      });
+      setStatus(data);
+    } catch (err: any) {
+      toast.error(`Failed to load index status: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleReindex() {
+    setIndexing(true);
+    try {
+      const result = await apiFetch<IndexResponse>('/api/codebase/index', {
+        method: 'POST',
+        body: JSON.stringify({ repo: repo || undefined, force: true }),
+      });
+      toast.success(`Indexed ${result.fileCount} files, ${result.symbolCount} symbols in ${(result.durationMs / 1000).toFixed(1)}s`);
+      await loadStatus();
+      onReindex();
+    } catch (err: any) {
+      toast.error(`Indexing failed: ${err.message}`);
+    } finally {
+      setIndexing(false);
+    }
+  }
+
+  if (loading || !status) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+      </div>
+    );
+  }
+
+  const isStale = status.lastIndexedAt && Date.now() - new Date(status.lastIndexedAt).getTime() > 86400000;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold text-zinc-300">Index Status</h3>
+          <Button
+            onClick={handleReindex}
+            disabled={indexing}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-medium disabled:opacity-40"
+          >
+            {indexing ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Indexing...
+              </>
+            ) : (
+              <>
+                <RefreshCw className="w-3.5 h-3.5" />
+                Re-index
+              </>
+            )}
+          </Button>
+        </div>
+
+        {!status.indexed ? (
+          <div className="text-center py-8">
+            <AlertCircle className="w-8 h-8 text-zinc-600 mx-auto mb-2" />
+            <p className="text-sm text-zinc-500">Not yet indexed</p>
+            <p className="text-xs text-zinc-600 mt-1">Click "Re-index" to start</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Last indexed */}
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">Last indexed</span>
+              <span className={`font-medium ${isStale ? 'text-amber-400' : 'text-zinc-300'}`}>
+                {status.lastIndexedAt ? relativeTime(status.lastIndexedAt) : 'Never'}
+                {isStale && <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-300">Stale</span>}
+              </span>
+            </div>
+
+            {/* Stats */}
+            <div className="grid grid-cols-3 gap-3">
+              <div className="rounded-lg bg-zinc-800/50 p-3">
+                <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Files</div>
+                <div className="text-lg font-bold text-zinc-200 mt-1">{status.fileCount?.toLocaleString() || 0}</div>
+              </div>
+              <div className="rounded-lg bg-zinc-800/50 p-3">
+                <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Symbols</div>
+                <div className="text-lg font-bold text-violet-300 mt-1">{status.symbolCount?.toLocaleString() || 0}</div>
+              </div>
+              <div className="rounded-lg bg-zinc-800/50 p-3">
+                <div className="text-[10px] uppercase text-zinc-600 tracking-wider">Imports</div>
+                <div className="text-lg font-bold text-blue-300 mt-1">{status.importCount?.toLocaleString() || 0}</div>
+              </div>
+            </div>
+
+            {/* Languages */}
+            {status.languages && Object.keys(status.languages).length > 0 && (
+              <div>
+                <h4 className="text-xs text-zinc-500 uppercase tracking-wider mb-2">Languages</h4>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(status.languages).map(([lang, count]) => (
+                    <Badge
+                      key={lang}
+                      variant="secondary"
+                      className="text-[10px] px-2 py-0.5"
+                      style={{ backgroundColor: getLanguageColor(lang) }}
+                    >
+                      {lang} ({count})
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── File Detail Sidebar ───────────────────────────── */
+
+interface FileDetailProps {
+  file: string;
+  repo?: string;
+  onClose: () => void;
+}
+
+function FileDetail({ file, repo, onClose }: FileDetailProps) {
+  const [context, setContext] = useState<FileContextResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadContext();
+  }, [file, repo]);
+
+  async function loadContext() {
+    setLoading(true);
+    try {
+      const data = await apiFetch<FileContextResponse>('/api/codebase/file-context', {
+        method: 'POST',
+        body: JSON.stringify({ file, repo: repo || undefined }),
+      });
+      setContext(data);
+    } catch (err: any) {
+      toast.error(`Failed to load file context: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (loading || !context) {
+    return (
+      <div className="fixed right-0 top-16 bottom-0 w-96 bg-zinc-900 border-l border-zinc-800 p-4 overflow-y-auto">
+        <div className="flex items-center justify-center h-full">
+          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed right-0 top-16 bottom-0 w-96 bg-zinc-900 border-l border-zinc-800 p-4 overflow-y-auto z-50">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-zinc-300 truncate flex-1">{file.split('/').pop()}</h3>
+        <button
+          onClick={onClose}
+          className="text-zinc-500 hover:text-zinc-300 transition-colors text-xl leading-none"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {/* File path */}
+        <div>
+          <h4 className="text-[10px] uppercase text-zinc-600 tracking-wider mb-1">Path</h4>
+          <p className="text-xs text-zinc-400 font-mono break-all">{file}</p>
+        </div>
+
+        {/* Symbols */}
+        {context.symbols.length > 0 && (
+          <div>
+            <h4 className="text-[10px] uppercase text-zinc-600 tracking-wider mb-2">Symbols ({context.symbols.length})</h4>
+            <div className="space-y-1">
+              {context.symbols.map((sym, idx) => (
+                <div key={idx} className="flex items-center gap-2 py-1.5 px-2 rounded-lg bg-zinc-800/50 text-xs">
+                  <Badge variant="secondary" className={`text-[10px] px-1.5 py-0.5 ${getKindBadgeColor(sym.kind)}`}>
+                    {sym.kind}
+                  </Badge>
+                  <span className="text-zinc-300 font-medium truncate flex-1">{sym.name}</span>
+                  <span className="text-zinc-600 shrink-0">@{sym.line}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Imports */}
+        {context.imports.length > 0 && (
+          <div>
+            <h4 className="text-[10px] uppercase text-zinc-600 tracking-wider mb-2">Imports ({context.imports.length})</h4>
+            <div className="space-y-1">
+              {context.imports.map((imp, idx) => (
+                <div key={idx} className="py-1.5 px-2 rounded-lg bg-zinc-800/50 text-xs text-zinc-400 font-mono truncate">
+                  {imp}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Imported by */}
+        {context.importedBy.length > 0 && (
+          <div>
+            <h4 className="text-[10px] uppercase text-zinc-600 tracking-wider mb-2">Imported By ({context.importedBy.length})</h4>
+            <div className="space-y-1">
+              {context.importedBy.map((imp, idx) => (
+                <div key={idx} className="py-1.5 px-2 rounded-lg bg-zinc-800/50 text-xs text-zinc-400 font-mono truncate">
+                  {imp}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Main Page ─────────────────────────────────────── */
+
+export default function Codebase() {
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-6 max-w-7xl">
+      <PageHeader
+        icon={Code2}
+        title="Codebase"
+        subtitle="Interactive codebase visualization and exploration"
+      />
+
+      {/* Index status at top */}
+      <IndexStatus onReindex={() => {}} />
+
+      {/* Tabs */}
+      <Tabs defaultValue="graph">
+        <TabsList>
+          <TabsTrigger value="graph" className="flex items-center gap-2">
+            <GitBranch className="w-4 h-4" /> Dependency Graph
+          </TabsTrigger>
+          <TabsTrigger value="overview" className="flex items-center gap-2">
+            <Database className="w-4 h-4" /> Architecture
+          </TabsTrigger>
+          <TabsTrigger value="search" className="flex items-center gap-2">
+            <Search className="w-4 h-4" /> Symbol Search
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="graph">
+          <GraphView onFileSelect={setSelectedFile} />
+        </TabsContent>
+
+        <TabsContent value="overview">
+          <ArchitectureOverview />
+        </TabsContent>
+
+        <TabsContent value="search">
+          <SymbolSearch onFileSelect={setSelectedFile} />
+        </TabsContent>
+      </Tabs>
+
+      {/* File detail sidebar */}
+      {selectedFile && (
+        <FileDetail file={selectedFile} onClose={() => setSelectedFile(null)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #181

### New page: `/codebase`

**Dependency Graph** (ReactFlow)
- Force-directed interactive graph of file dependencies
- Nodes colour-coded by language (TS=blue, Python=green, Go=cyan)
- Click node → sidebar with symbols, imports, importers
- Zoom, pan, drag

**Architecture Overview**
- File/symbol/import stat cards
- Language distribution pie chart (Recharts)
- Most-imported files leaderboard

**Symbol Search**
- Search across all indexed repos
- Kind badges (function/class/interface/type)
- Click through to file detail

**Index Status**
- Per-repo index freshness with stale indicator (>24h)
- Re-index button
- Language breakdown badges

### Integration
- Route: `/codebase`
- Sidebar nav entry with Code2 icon
- Uses existing `apiFetch` helper
- Matches dark zinc theme

### Verification
- `npx tsc --noEmit` — 0 errors ✅
- 163/163 tests pass ✅
- Control + indexer builds clean ✅

840 lines, 1 new page component.