### PR TITLE
feat: tree-sitter AST parsing for codebase indexer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9429,6 +9429,83 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/tree-sitter-go": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.25.0.tgz",
+      "integrity": "sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.25.0.tgz",
+      "integrity": "sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "dev": true,
@@ -10414,6 +10491,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.7.tgz",
+      "integrity": "sha512-KiZhelTvBA/ziUHEO7Emb75cGVAq8iGZNabYaZm53Zpy50NsXyOW+xSHlwHt5CVg/TRPZBfeVLTTobF0LjFJ1w==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -11138,7 +11221,11 @@
       "name": "@coderage-labs/armada-indexer",
       "version": "0.1.0",
       "dependencies": {
-        "better-sqlite3": "^11.7.0"
+        "better-sqlite3": "^11.7.0",
+        "tree-sitter-go": "^0.25.0",
+        "tree-sitter-python": "^0.25.0",
+        "tree-sitter-typescript": "^0.23.2",
+        "web-tree-sitter": "^0.26.7"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coderage-labs/armada-indexer",
   "version": "0.1.0",
-  "description": "Codebase intelligence indexer \u2014 tree-sitter AST parsing into a queryable knowledge graph",
+  "description": "Codebase intelligence indexer — tree-sitter AST parsing into a queryable knowledge graph",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "better-sqlite3": "^11.7.0"
+    "better-sqlite3": "^11.7.0",
+    "tree-sitter-go": "^0.25.0",
+    "tree-sitter-python": "^0.25.0",
+    "tree-sitter-typescript": "^0.23.2",
+    "web-tree-sitter": "^0.26.7"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -8,6 +8,9 @@ import { join, relative } from 'node:path';
 import { GraphStore } from './graph/store.js';
 import type { FileNode, SymbolNode, ImportEdge, Language, RepoIndex } from './graph/schema.js';
 import { detectLanguage, isParseable, shouldIgnorePath } from './parsers/detect.js';
+import { treeSitterParse } from './parsers/tree-sitter-parser.js';
+import { ensureInit } from './parsers/tree-sitter-init.js';
+// Regex parsers kept as fallback
 import { parseTypeScript } from './parsers/typescript-parser.js';
 import { parsePython } from './parsers/python-parser.js';
 import { parseGo } from './parsers/go-parser.js';
@@ -44,6 +47,11 @@ export async function indexRepository(opts: IndexOptions): Promise<IndexResult> 
   let symbolCount = 0;
   let importCount = 0;
 
+  // Initialise tree-sitter WASM once before parsing
+  await ensureInit().catch(err => {
+    onProgress?.(`Tree-sitter init failed, falling back to regex: ${err.message}`);
+  });
+
   onProgress?.(`Indexing ${repoFullName} from ${repoPath}`);
 
   // Walk the directory tree
@@ -73,7 +81,7 @@ export async function indexRepository(opts: IndexOptions): Promise<IndexResult> 
       // Skip if unchanged (incremental)
       if (incremental && existingFiles.get(relPath) === hash) continue;
 
-      const result = indexFile({
+      const result = await indexFile({
         repoId, filePath: relPath, content, language, hash, store,
       });
 
@@ -121,14 +129,14 @@ export async function indexRepository(opts: IndexOptions): Promise<IndexResult> 
 /**
  * Index a single file — parse and store its symbols + imports.
  */
-export function indexFile(opts: {
+export async function indexFile(opts: {
   repoId: string;
   filePath: string;
   content: string;
   language: Language;
   hash: string;
   store: GraphStore;
-}): { symbols: number; imports: number } {
+}): Promise<{ symbols: number; imports: number }> {
   const { repoId, filePath, content, language, hash, store } = opts;
   const fileId = `${repoId}:${filePath}`;
   const now = new Date().toISOString();
@@ -154,7 +162,7 @@ export function indexFile(opts: {
   // Parse if supported language
   if (!isParseable(language)) return { symbols: 0, imports: 0 };
 
-  const parsed = parseSource(content, language, filePath);
+  const parsed = await parseSource(content, language, filePath);
   let symbolCount = 0;
   let importCount = 0;
 
@@ -189,11 +197,18 @@ export function indexFile(opts: {
 
 // ── Internal helpers ────────────────────────────────────────────────
 
-function parseSource(
+async function parseSource(
   content: string,
   language: Language,
   filePath: string,
-): { symbols: Omit<SymbolNode, 'id' | 'fileId'>[]; imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[] } {
+): Promise<{ symbols: Omit<SymbolNode, 'id' | 'fileId'>[]; imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[] }> {
+  // Try tree-sitter first (accurate AST), fall back to regex
+  try {
+    const result = await treeSitterParse(content, language, filePath);
+    if (result.symbols.length > 0 || result.imports.length > 0) return result;
+  } catch { /* tree-sitter failed, fall back */ }
+
+  // Regex fallback
   switch (language) {
     case 'typescript':
     case 'javascript':

--- a/packages/indexer/src/parsers/index.ts
+++ b/packages/indexer/src/parsers/index.ts
@@ -1,4 +1,7 @@
 export { detectLanguage, isParseable, shouldIgnorePath } from './detect.js';
+export { treeSitterParse } from './tree-sitter-parser.js';
+export { ensureInit, getLanguage, getSupportedLanguages } from './tree-sitter-init.js';
+// Regex fallbacks
 export { parseTypeScript } from './typescript-parser.js';
 export { parsePython } from './python-parser.js';
 export { parseGo } from './go-parser.js';

--- a/packages/indexer/src/parsers/tree-sitter-init.ts
+++ b/packages/indexer/src/parsers/tree-sitter-init.ts
@@ -1,0 +1,77 @@
+/**
+ * Tree-sitter initialisation — lazy singleton.
+ * Uses web-tree-sitter (WASM) for cross-platform compatibility.
+ */
+
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+let _initPromise: Promise<void> | null = null;
+let _Parser: any = null;
+const _languages: Map<string, any> = new Map();
+
+/**
+ * Resolve the path to a WASM grammar file.
+ * Searches node_modules from the indexer package directory.
+ */
+function findWasmPath(packageName: string, wasmFile: string): string {
+  // Try relative to this file first
+  const candidates = [
+    resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'node_modules', packageName, wasmFile),
+    resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', 'node_modules', packageName, wasmFile),
+    resolve(process.cwd(), 'node_modules', packageName, wasmFile),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  throw new Error(`WASM file not found: ${packageName}/${wasmFile}. Searched: ${candidates.join(', ')}`);
+}
+
+async function init(): Promise<void> {
+  if (_Parser) return;
+  // Dynamic import for ESM compatibility
+  const mod = await import('web-tree-sitter');
+  const TreeSitter = mod.default || mod;
+  await TreeSitter.Parser.init();
+  _Parser = TreeSitter;
+}
+
+export async function ensureInit(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = init();
+  }
+  await _initPromise;
+}
+
+export function getParser(): any {
+  if (!_Parser) throw new Error('Tree-sitter not initialised. Call ensureInit() first.');
+  return _Parser;
+}
+
+const GRAMMAR_MAP: Record<string, { package: string; wasm: string }> = {
+  typescript: { package: 'tree-sitter-typescript', wasm: 'tree-sitter-typescript.wasm' },
+  tsx:        { package: 'tree-sitter-typescript', wasm: 'tree-sitter-tsx.wasm' },
+  javascript: { package: 'tree-sitter-typescript', wasm: 'tree-sitter-typescript.wasm' }, // TS parser handles JS
+  jsx:        { package: 'tree-sitter-typescript', wasm: 'tree-sitter-tsx.wasm' },
+  python:     { package: 'tree-sitter-python', wasm: 'tree-sitter-python.wasm' },
+  go:         { package: 'tree-sitter-go', wasm: 'tree-sitter-go.wasm' },
+};
+
+export async function getLanguage(lang: string): Promise<any> {
+  if (_languages.has(lang)) return _languages.get(lang);
+  
+  const grammar = GRAMMAR_MAP[lang];
+  if (!grammar) return null;
+  
+  await ensureInit();
+  const TreeSitter = getParser();
+  const wasmPath = findWasmPath(grammar.package, grammar.wasm);
+  const language = await TreeSitter.Language.load(wasmPath);
+  _languages.set(lang, language);
+  return language;
+}
+
+export function getSupportedLanguages(): string[] {
+  return Object.keys(GRAMMAR_MAP);
+}

--- a/packages/indexer/src/parsers/tree-sitter-parser.ts
+++ b/packages/indexer/src/parsers/tree-sitter-parser.ts
@@ -1,0 +1,412 @@
+/**
+ * Universal tree-sitter parser — extracts symbols and imports from AST.
+ * Handles TypeScript, JavaScript, Python, Go via language-specific extractors.
+ */
+
+import type { SymbolNode, ImportEdge, SymbolKind } from '../graph/schema.js';
+import { ensureInit, getParser, getLanguage } from './tree-sitter-init.js';
+
+export interface ParseResult {
+  symbols: Omit<SymbolNode, 'id' | 'fileId'>[];
+  imports: Omit<ImportEdge, 'id' | 'fromFileId' | 'toFileId'>[];
+}
+
+/**
+ * Parse source code using tree-sitter AST.
+ */
+export async function treeSitterParse(source: string, language: string, filePath?: string): Promise<ParseResult> {
+  await ensureInit();
+  const TreeSitter = getParser();
+  const lang = await getLanguage(language);
+  if (!lang) return { symbols: [], imports: [] };
+
+  const parser = new TreeSitter.Parser();
+  parser.setLanguage(lang);
+  const tree = parser.parse(source);
+  const root = tree.rootNode;
+
+  switch (language) {
+    case 'typescript':
+    case 'javascript':
+    case 'tsx':
+    case 'jsx':
+      return extractTypeScript(root);
+    case 'python':
+      return extractPython(root);
+    case 'go':
+      return extractGo(root);
+    default:
+      return { symbols: [], imports: [] };
+  }
+}
+
+// ── TypeScript / JavaScript ─────────────────────────────────────────
+
+function extractTypeScript(root: any): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+
+  function walk(node: any, depth: number = 0): void {
+    const line = node.startPosition.row + 1;
+
+    switch (node.type) {
+      case 'import_statement': {
+        const source = node.childForFieldName('source')?.text?.replace(/['"]/g, '') || '';
+        const importClause = node.children.find((c: any) => c.type === 'import_clause');
+        const namedImports = node.descendantsOfType('import_specifier');
+        const namespaceImport = node.descendantsOfType('namespace_import');
+        const isTypeOnly = node.text.includes('import type');
+        
+        const syms: string[] = [];
+        for (const spec of namedImports) {
+          syms.push(spec.childForFieldName('name')?.text || spec.text);
+        }
+        // Default import
+        const defaultImport = importClause?.children?.find(
+          (c: any) => c.type === 'identifier'
+        );
+        if (defaultImport) syms.push(defaultImport.text);
+        // Namespace import
+        if (namespaceImport.length > 0) syms.push('*');
+
+        if (source) {
+          imports.push({
+            toModule: source,
+            symbols: syms.length > 0 ? syms : [source.split('/').pop()!],
+            isDefault: !!defaultImport && syms.length <= 1,
+            isNamespace: namespaceImport.length > 0,
+            line,
+          });
+        }
+        break;
+      }
+
+      case 'export_statement': {
+        const declaration = node.childForFieldName('declaration') ||
+          node.children.find((c: any) =>
+            ['function_declaration', 'class_declaration', 'interface_declaration',
+             'type_alias_declaration', 'enum_declaration', 'lexical_declaration',
+             'abstract_class_declaration'].includes(c.type)
+          );
+        if (declaration) {
+          extractDeclaration(declaration, true, symbols, line, depth);
+        }
+        // export default
+        if (node.text.startsWith('export default')) {
+          const value = node.children.find((c: any) => c.type === 'identifier');
+          if (value) {
+            symbols.push({
+              name: value.text,
+              kind: 'variable',
+              line,
+              exported: true,
+            });
+          }
+        }
+        break;
+      }
+
+      case 'function_declaration':
+      case 'class_declaration':
+      case 'interface_declaration':
+      case 'type_alias_declaration':
+      case 'enum_declaration':
+      case 'lexical_declaration':
+      case 'abstract_class_declaration':
+        if (depth === 0) {
+          extractDeclaration(node, false, symbols, line, depth);
+        }
+        break;
+    }
+
+    // Recurse into top-level children only
+    if (depth === 0) {
+      for (let i = 0; i < node.childCount; i++) {
+        walk(node.child(i), depth + 1);
+      }
+    }
+  }
+
+  walk(root);
+  return { symbols, imports };
+}
+
+function extractDeclaration(
+  node: any,
+  exported: boolean,
+  symbols: ParseResult['symbols'],
+  line: number,
+  depth: number,
+): void {
+  const kindMap: Record<string, SymbolKind> = {
+    function_declaration: 'function',
+    class_declaration: 'class',
+    abstract_class_declaration: 'class',
+    interface_declaration: 'interface',
+    type_alias_declaration: 'type',
+    enum_declaration: 'enum',
+  };
+
+  const kind = kindMap[node.type];
+  if (kind) {
+    const name = node.childForFieldName('name')?.text;
+    if (name) {
+      // Build signature from first line
+      const sig = node.text.split('\n')[0].replace(/\{.*$/, '').trim();
+      symbols.push({ name, kind, line: node.startPosition.row + 1, signature: sig, exported });
+
+      // Extract methods from classes
+      if (kind === 'class') {
+        const body = node.childForFieldName('body');
+        if (body) {
+          for (let i = 0; i < body.childCount; i++) {
+            const member = body.child(i);
+            if (member.type === 'method_definition' || member.type === 'public_field_definition') {
+              const mName = member.childForFieldName('name')?.text;
+              if (mName) {
+                const mSig = member.text.split('\n')[0].replace(/\{.*$/, '').trim();
+                symbols.push({
+                  name: mName,
+                  kind: 'method',
+                  line: member.startPosition.row + 1,
+                  signature: mSig,
+                  exported,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+    return;
+  }
+
+  // lexical_declaration (const/let/var)
+  if (node.type === 'lexical_declaration') {
+    const declarators = node.descendantsOfType('variable_declarator');
+    for (const decl of declarators) {
+      const name = decl.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({ name, kind: 'variable', line: node.startPosition.row + 1, exported });
+      }
+    }
+  }
+}
+
+// ── Python ──────────────────────────────────────────────────────────
+
+function extractPython(root: any): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+
+  for (let i = 0; i < root.childCount; i++) {
+    const node = root.child(i);
+    const line = node.startPosition.row + 1;
+
+    switch (node.type) {
+      case 'import_statement': {
+        // import module
+        const names = node.descendantsOfType('dotted_name');
+        for (const n of names) {
+          imports.push({
+            toModule: n.text,
+            symbols: [n.text.split('.').pop()!],
+            isDefault: true,
+            isNamespace: false,
+            line,
+          });
+        }
+        break;
+      }
+
+      case 'import_from_statement': {
+        // from module import X, Y
+        const moduleName = node.childForFieldName('module_name')?.text || 
+          node.children.find((c: any) => c.type === 'dotted_name')?.text || '';
+        const importedNames = node.descendantsOfType('dotted_name')
+          .filter((n: any) => n.text !== moduleName)
+          .map((n: any) => n.text);
+        // Also get aliased imports
+        const aliases = node.descendantsOfType('aliased_import');
+        for (const a of aliases) {
+          const name = a.childForFieldName('name')?.text;
+          if (name) importedNames.push(name);
+        }
+        const wildcard = node.children.find((c: any) => c.type === 'wildcard_import');
+        
+        imports.push({
+          toModule: moduleName,
+          symbols: wildcard ? ['*'] : importedNames,
+          isDefault: false,
+          isNamespace: !!wildcard,
+          line,
+        });
+        break;
+      }
+
+      case 'function_definition': {
+        const name = node.childForFieldName('name')?.text;
+        const params = node.childForFieldName('parameters')?.text || '()';
+        const returnType = node.childForFieldName('return_type')?.text;
+        if (name) {
+          symbols.push({
+            name,
+            kind: 'function',
+            line,
+            signature: `def ${name}${params}${returnType ? ` -> ${returnType}` : ''}`,
+            exported: !name.startsWith('_'),
+          });
+        }
+        break;
+      }
+
+      case 'class_definition': {
+        const name = node.childForFieldName('name')?.text;
+        const superclasses = node.childForFieldName('superclasses')?.text || '';
+        if (name) {
+          symbols.push({
+            name,
+            kind: 'class',
+            line,
+            signature: `class ${name}${superclasses}`,
+            exported: !name.startsWith('_'),
+          });
+          // Extract methods
+          const body = node.childForFieldName('body');
+          if (body) {
+            for (let j = 0; j < body.childCount; j++) {
+              const member = body.child(j);
+              if (member.type === 'function_definition') {
+                const mName = member.childForFieldName('name')?.text;
+                const mParams = member.childForFieldName('parameters')?.text || '()';
+                if (mName) {
+                  symbols.push({
+                    name: mName,
+                    kind: 'method',
+                    line: member.startPosition.row + 1,
+                    signature: `def ${mName}${mParams}`,
+                    exported: !mName.startsWith('_'),
+                  });
+                }
+              }
+            }
+          }
+        }
+        break;
+      }
+
+      case 'decorated_definition': {
+        // Handle @decorator\ndef/class
+        const inner = node.children.find((c: any) =>
+          ['function_definition', 'class_definition'].includes(c.type)
+        );
+        if (inner) {
+          // Re-process as if it were top-level
+          const fakeParsed = extractPython({ childCount: 1, child: () => inner } as any);
+          symbols.push(...fakeParsed.symbols);
+        }
+        break;
+      }
+    }
+  }
+
+  return { symbols, imports };
+}
+
+// ── Go ──────────────────────────────────────────────────────────────
+
+function extractGo(root: any): ParseResult {
+  const symbols: ParseResult['symbols'] = [];
+  const imports: ParseResult['imports'] = [];
+
+  for (let i = 0; i < root.childCount; i++) {
+    const node = root.child(i);
+    const line = node.startPosition.row + 1;
+
+    switch (node.type) {
+      case 'import_declaration': {
+        const specs = node.descendantsOfType('import_spec');
+        for (const spec of specs) {
+          const path = spec.childForFieldName('path')?.text?.replace(/"/g, '') || '';
+          const alias = spec.childForFieldName('name')?.text;
+          if (path) {
+            imports.push({
+              toModule: path,
+              symbols: [alias || path.split('/').pop()!],
+              isDefault: true,
+              isNamespace: alias === '.',
+              line: spec.startPosition.row + 1,
+            });
+          }
+        }
+        // Single import (no parens)
+        const singlePath = node.childForFieldName('path')?.text?.replace(/"/g, '');
+        if (singlePath) {
+          imports.push({
+            toModule: singlePath,
+            symbols: [singlePath.split('/').pop()!],
+            isDefault: true,
+            isNamespace: false,
+            line,
+          });
+        }
+        break;
+      }
+
+      case 'function_declaration': {
+        const name = node.childForFieldName('name')?.text;
+        if (name) {
+          const sig = node.text.split('\n')[0].replace(/\{.*$/, '').trim();
+          symbols.push({
+            name,
+            kind: 'function',
+            line,
+            signature: sig,
+            exported: name[0] === name[0].toUpperCase(),
+          });
+        }
+        break;
+      }
+
+      case 'method_declaration': {
+        const name = node.childForFieldName('name')?.text;
+        if (name) {
+          const sig = node.text.split('\n')[0].replace(/\{.*$/, '').trim();
+          symbols.push({
+            name,
+            kind: 'method',
+            line,
+            signature: sig,
+            exported: name[0] === name[0].toUpperCase(),
+          });
+        }
+        break;
+      }
+
+      case 'type_declaration': {
+        const specs = node.descendantsOfType('type_spec');
+        for (const spec of specs) {
+          const name = spec.childForFieldName('name')?.text;
+          const typeNode = spec.childForFieldName('type');
+          if (name) {
+            let kind: SymbolKind = 'type';
+            if (typeNode?.type === 'struct_type') kind = 'struct';
+            else if (typeNode?.type === 'interface_type') kind = 'interface';
+            
+            const sig = spec.text.split('\n')[0].replace(/\{.*$/, '').trim();
+            symbols.push({
+              name,
+              kind,
+              line: spec.startPosition.row + 1,
+              signature: `type ${sig}`,
+              exported: name[0] === name[0].toUpperCase(),
+            });
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  return { symbols, imports };
+}


### PR DESCRIPTION
Follow-up to #180 — replaces regex parsers with proper tree-sitter AST analysis.

### What changed
- **web-tree-sitter** (WASM) for cross-platform parsing — no native compilation needed
- **TypeScript/JS parser**: classes with methods, interfaces, types, enums, named/default/namespace imports
- **Python parser**: classes with methods, decorated definitions, from/import statements
- **Go parser**: functions, methods, structs, interfaces, type aliases, import blocks
- Regex parsers kept as **fallback** if tree-sitter fails to load
- Lazy singleton WASM init — loaded once, cached across all parse calls

### Why
Chris explicitly asked for tree-sitter. Regex was a shortcut that missed edge cases (nested classes, decorated functions, complex import patterns). AST parsing is accurate from day one.

### Verification
- `npx tsc --noEmit` — 0 errors ✅
- 163/163 tests pass ✅
- Functional test: TS, Python, Go all parse correctly with class methods, import specifiers, etc.