### PR TITLE
feat: Agent Learning System Phase 1+2 + batch fixes (#185, #153, #156, #174)

### DIFF
--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -54,6 +54,7 @@ import { notificationChannelsRoutes } from './routes/notification-channels.js';
 import workflowArtifactRoutes from './routes/workflow-artifacts.js';
 import projectReposRoutes from './routes/project-repos.js';
 import { codebaseRouter } from './routes/codebase.js';
+import { learningRouter } from './routes/learning.js';
 
 export interface AppOptions {
   nodeManager: NodeManager;
@@ -119,6 +120,7 @@ export function createApp(opts: AppOptions): express.Express {
   app.use('/api/projects/:id/integrations', createProjectIntegrationRoutes(nodeManager));
   app.use('/api/projects/:id/repos2', projectReposRoutes);
   app.use('/api/codebase', codebaseRouter);
+  app.use('/api/learning', learningRouter);
   app.use('/api/webhooks', webhookRoutes);
   app.use('/api/webhooks/inbound', webhooksInboundMgmtRouter);
   app.use('/api/tools', createToolRoutes(nodeManager));

--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -695,3 +695,53 @@ export const notificationChannels = sqliteTable('notification_channels', {
   createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text('updated_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
+
+// ── Learning System (#185) ──────────────────────────────────────────
+
+export const reviewRecords = sqliteTable('review_records', {
+  id: text('id').primaryKey(),
+  runId: text('run_id').notNull(),
+  stepId: text('step_id').notNull(),
+  reviewer: text('reviewer'),
+  executor: text('executor'),
+  score: integer('score').notNull(),
+  result: text('result').notNull(), // approved | rejected
+  feedback: text('feedback').default(''),
+  issuesJson: text('issues_json').default('[]'),
+  round: integer('round').default(1),
+  category: text('category'),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export const agentLessons = sqliteTable('agent_lessons', {
+  id: text('id').primaryKey(),
+  agentId: text('agent_id').notNull(),
+  projectId: text('project_id'),
+  lesson: text('lesson').notNull(),
+  source: text('source').default('review'),
+  severity: text('severity').default('medium'),
+  reviewId: text('review_id'),
+  active: integer('active').default(1),
+  timesInjected: integer('times_injected').default(0),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  resolvedAt: text('resolved_at'),
+});
+
+export const projectConventions = sqliteTable('project_conventions', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull(),
+  convention: text('convention').notNull(),
+  source: text('source').default('extracted'),
+  evidenceCount: integer('evidence_count').default(1),
+  active: integer('active').default(1),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export const agentScores = sqliteTable('agent_scores', {
+  agentId: text('agent_id').notNull(),
+  category: text('category').notNull().default('overall'),
+  totalScore: integer('total_score').default(0),
+  reviewCount: integer('review_count').default(0),
+  avgScore: real('avg_score').default(0),
+  lastUpdated: text('last_updated').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -531,6 +531,67 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 41,
+    description: 'Create review_records, agent_lessons, and project_conventions tables (#185)',
+    run(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS review_records (
+          id TEXT PRIMARY KEY,
+          run_id TEXT NOT NULL,
+          step_id TEXT NOT NULL,
+          reviewer TEXT,
+          executor TEXT,
+          score INTEGER NOT NULL CHECK(score BETWEEN 1 AND 5),
+          result TEXT NOT NULL CHECK(result IN ('approved', 'rejected')),
+          feedback TEXT DEFAULT '',
+          issues_json TEXT DEFAULT '[]',
+          round INTEGER DEFAULT 1,
+          category TEXT,
+          created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_review_records_run ON review_records(run_id);
+        CREATE INDEX IF NOT EXISTS idx_review_records_executor ON review_records(executor);
+
+        CREATE TABLE IF NOT EXISTS agent_lessons (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          project_id TEXT,
+          lesson TEXT NOT NULL,
+          source TEXT DEFAULT 'review',
+          severity TEXT DEFAULT 'medium',
+          review_id TEXT,
+          active INTEGER DEFAULT 1,
+          times_injected INTEGER DEFAULT 0,
+          created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+          resolved_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_lessons_agent ON agent_lessons(agent_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_lessons_active ON agent_lessons(active);
+
+        CREATE TABLE IF NOT EXISTS project_conventions (
+          id TEXT PRIMARY KEY,
+          project_id TEXT NOT NULL,
+          convention TEXT NOT NULL,
+          source TEXT DEFAULT 'extracted',
+          evidence_count INTEGER DEFAULT 1,
+          active INTEGER DEFAULT 1,
+          created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_project_conventions_project ON project_conventions(project_id);
+
+        CREATE TABLE IF NOT EXISTS agent_scores (
+          agent_id TEXT NOT NULL,
+          category TEXT NOT NULL DEFAULT 'overall',
+          total_score INTEGER DEFAULT 0,
+          review_count INTEGER DEFAULT 0,
+          avg_score REAL DEFAULT 0,
+          last_updated TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+          PRIMARY KEY (agent_id, category)
+        );
+      `);
+    },
+  },
 ];
 
 /**

--- a/packages/control/src/routes/learning.ts
+++ b/packages/control/src/routes/learning.ts
@@ -1,0 +1,325 @@
+/**
+ * Learning system API routes — reviews, scoring, lessons, conventions.
+ * Phase 1+2 of #185.
+ */
+
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import { getDrizzle } from '../db/drizzle.js';
+import { reviewRecords, agentLessons, projectConventions, agentScores } from '../db/drizzle-schema.js';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import { requireScope } from '../middleware/scopes.js';
+import { registerToolDef } from '../utils/tool-registry.js';
+
+export const learningRouter = Router();
+
+// ── Tool definitions ────────────────────────────────────────────────
+
+const LEARNING_TOOLS = [
+  { category: 'learning', scope: 'workflows:write', name: 'armada_review_submit', description: 'Submit a structured review for a workflow step. Includes score (1-5), result (approved/rejected), and feedback.', method: 'POST', path: '/api/learning/reviews',
+    parameters: [
+      { name: 'runId', type: 'string', description: 'Workflow run ID', required: true },
+      { name: 'stepId', type: 'string', description: 'Step ID being reviewed', required: true },
+      { name: 'score', type: 'number', description: 'Quality score 1-5 (1=poor, 5=excellent)', required: true },
+      { name: 'result', type: 'string', description: 'approved or rejected', required: true },
+      { name: 'feedback', type: 'string', description: 'Detailed feedback text' },
+      { name: 'issues', type: 'string', description: 'JSON array of specific issues found' },
+    ] },
+  { category: 'learning', scope: 'workflows:read', name: 'armada_agent_score', description: 'Get an agent\'s quality scores and review history.', method: 'POST', path: '/api/learning/agent-score',
+    parameters: [
+      { name: 'agent', type: 'string', description: 'Agent name', required: true },
+    ] },
+  { category: 'learning', scope: 'workflows:read', name: 'armada_agent_lessons', description: 'Get an agent\'s active lessons (things it should remember from past reviews).', method: 'POST', path: '/api/learning/agent-lessons',
+    parameters: [
+      { name: 'agent', type: 'string', description: 'Agent name', required: true },
+      { name: 'projectId', type: 'string', description: 'Filter by project' },
+    ] },
+  { category: 'learning', scope: 'projects:read', name: 'armada_project_conventions', description: 'Get a project\'s conventions (patterns extracted from review feedback).', method: 'POST', path: '/api/learning/conventions',
+    parameters: [
+      { name: 'projectId', type: 'string', description: 'Project ID', required: true },
+    ] },
+] as const;
+
+for (const tool of LEARNING_TOOLS) {
+  registerToolDef(tool as any);
+}
+
+// ── Rank system ─────────────────────────────────────────────────────
+
+interface Rank {
+  name: string;
+  title: string;
+  minScore: number;
+}
+
+const RANKS: Rank[] = [
+  { name: 'admiral', title: 'Admiral', minScore: 200 },
+  { name: 'captain', title: 'Captain', minScore: 100 },
+  { name: 'commander', title: 'Commander', minScore: 50 },
+  { name: 'lieutenant', title: 'Lieutenant', minScore: 20 },
+  { name: 'cadet', title: 'Cadet', minScore: 0 },
+];
+
+function getRank(totalScore: number): Rank {
+  return RANKS.find(r => totalScore >= r.minScore) || RANKS[RANKS.length - 1];
+}
+
+// ── Routes ──────────────────────────────────────────────────────────
+
+// POST /api/learning/reviews — submit a review
+learningRouter.post('/reviews', requireScope('workflows:write'), (req, res) => {
+  const { runId, stepId, score, result, feedback, issues, reviewer, executor, category } = req.body;
+
+  if (!runId || !stepId || !score || !result) {
+    return res.status(400).json({ error: 'runId, stepId, score, and result are required' });
+  }
+  if (score < 1 || score > 5) {
+    return res.status(400).json({ error: 'score must be between 1 and 5' });
+  }
+  if (!['approved', 'rejected'].includes(result)) {
+    return res.status(400).json({ error: 'result must be approved or rejected' });
+  }
+
+  const db = getDrizzle();
+  const id = randomUUID();
+
+  // Count existing reviews for this step (round number)
+  const existing = db.select({ id: reviewRecords.id }).from(reviewRecords)
+    .where(and(eq(reviewRecords.runId, runId), eq(reviewRecords.stepId, stepId))).all();
+  const round = existing.length + 1;
+
+  // Insert review record
+  db.insert(reviewRecords).values({
+    id,
+    runId,
+    stepId,
+    reviewer: reviewer || (req as any).user?.name || 'unknown',
+    executor: executor || null,
+    score,
+    result,
+    feedback: feedback || '',
+    issuesJson: typeof issues === 'string' ? issues : JSON.stringify(issues || []),
+    round,
+    category: category || null,
+  }).run();
+
+  // Update agent score
+  if (executor) {
+    const cat = category || 'overall';
+    const existingScore = db.select().from(agentScores)
+      .where(and(eq(agentScores.agentId, executor), eq(agentScores.category, cat))).get();
+
+    if (existingScore) {
+      const newCount = (existingScore.reviewCount || 0) + 1;
+      const newTotal = (existingScore.totalScore || 0) + score;
+      db.update(agentScores).set({
+        totalScore: newTotal,
+        reviewCount: newCount,
+        avgScore: newTotal / newCount,
+        lastUpdated: new Date().toISOString(),
+      }).where(and(eq(agentScores.agentId, executor), eq(agentScores.category, cat))).run();
+    } else {
+      db.insert(agentScores).values({
+        agentId: executor,
+        category: cat,
+        totalScore: score,
+        reviewCount: 1,
+        avgScore: score,
+      }).run();
+    }
+  }
+
+  // If rejected, extract lesson from feedback
+  if (result === 'rejected' && feedback && executor) {
+    const lessonId = randomUUID();
+    db.insert(agentLessons).values({
+      id: lessonId,
+      agentId: executor,
+      projectId: null, // Could be resolved from run
+      lesson: feedback,
+      source: 'review',
+      severity: score <= 2 ? 'high' : 'medium',
+      reviewId: id,
+    }).run();
+  }
+
+  const agentScore = executor
+    ? db.select().from(agentScores).where(and(eq(agentScores.agentId, executor), eq(agentScores.category, category || 'overall'))).get()
+    : null;
+
+  res.status(201).json({
+    id,
+    round,
+    ...(agentScore && {
+      agentScore: {
+        total: agentScore.totalScore,
+        average: agentScore.avgScore,
+        reviews: agentScore.reviewCount,
+        rank: getRank(agentScore.totalScore || 0),
+      },
+    }),
+  });
+});
+
+// GET /api/learning/reviews — list reviews for a run
+learningRouter.get('/reviews', requireScope('workflows:read'), (req, res) => {
+  const { runId, executor } = req.query;
+  const db = getDrizzle();
+
+  let query = db.select().from(reviewRecords);
+  if (runId) query = query.where(eq(reviewRecords.runId, runId as string)) as any;
+  if (executor) query = query.where(eq(reviewRecords.executor, executor as string)) as any;
+
+  const results = (query as any).orderBy(desc(reviewRecords.createdAt)).limit(50).all();
+  res.json(results);
+});
+
+// POST /api/learning/agent-score — get agent score + rank
+learningRouter.post('/agent-score', requireScope('workflows:read'), (req, res) => {
+  const { agent } = req.body;
+  if (!agent) return res.status(400).json({ error: 'agent is required' });
+
+  const db = getDrizzle();
+  const scores = db.select().from(agentScores).where(eq(agentScores.agentId, agent)).all();
+
+  const overall = scores.find(s => s.category === 'overall') || { totalScore: 0, reviewCount: 0, avgScore: 0 };
+  const categories = scores.filter(s => s.category !== 'overall');
+
+  res.json({
+    agent,
+    rank: getRank(overall.totalScore || 0),
+    overall: {
+      totalScore: overall.totalScore,
+      reviewCount: overall.reviewCount,
+      avgScore: overall.avgScore,
+    },
+    categories: categories.map(c => ({
+      category: c.category,
+      totalScore: c.totalScore,
+      reviewCount: c.reviewCount,
+      avgScore: c.avgScore,
+    })),
+  });
+});
+
+// POST /api/learning/agent-lessons — get active lessons for injection
+learningRouter.post('/agent-lessons', requireScope('workflows:read'), (req, res) => {
+  const { agent, projectId } = req.body;
+  if (!agent) return res.status(400).json({ error: 'agent is required' });
+
+  const db = getDrizzle();
+  let conditions = [eq(agentLessons.agentId, agent), eq(agentLessons.active, 1)];
+  if (projectId) conditions.push(eq(agentLessons.projectId, projectId));
+
+  const lessons = db.select().from(agentLessons)
+    .where(and(...conditions))
+    .orderBy(desc(agentLessons.createdAt))
+    .limit(10)
+    .all();
+
+  res.json(lessons);
+});
+
+// POST /api/learning/conventions — get project conventions
+learningRouter.post('/conventions', requireScope('projects:read'), (req, res) => {
+  const { projectId } = req.body;
+  if (!projectId) return res.status(400).json({ error: 'projectId is required' });
+
+  const db = getDrizzle();
+  const conventions = db.select().from(projectConventions)
+    .where(and(eq(projectConventions.projectId, projectId), eq(projectConventions.active, 1)))
+    .orderBy(desc(projectConventions.evidenceCount))
+    .all();
+
+  res.json(conventions);
+});
+
+// POST /api/learning/conventions/add — add a convention manually
+learningRouter.post('/conventions/add', requireScope('projects:write'), (req, res) => {
+  const { projectId, convention } = req.body;
+  if (!projectId || !convention) return res.status(400).json({ error: 'projectId and convention required' });
+
+  const db = getDrizzle();
+  const id = randomUUID();
+  db.insert(projectConventions).values({
+    id,
+    projectId,
+    convention,
+    source: 'manual',
+  }).run();
+
+  res.status(201).json({ id, convention });
+});
+
+// GET /api/learning/leaderboard — agent score leaderboard
+learningRouter.get('/leaderboard', requireScope('workflows:read'), (_req, res) => {
+  const db = getDrizzle();
+  const scores = db.select().from(agentScores)
+    .where(eq(agentScores.category, 'overall'))
+    .orderBy(desc(agentScores.totalScore))
+    .all();
+
+  res.json(scores.map(s => ({
+    agent: s.agentId,
+    totalScore: s.totalScore,
+    reviewCount: s.reviewCount,
+    avgScore: s.avgScore,
+    rank: getRank(s.totalScore || 0),
+  })));
+});
+
+// GET /api/learning/lessons/:agentId/context — formatted lesson context for prompt injection
+learningRouter.get('/lessons/:agentId/context', requireScope('workflows:read'), (req, res) => {
+  const agentId = req.params.agentId;
+  const projectId = req.query.projectId as string | undefined;
+  const db = getDrizzle();
+
+  // Get agent lessons
+  let conditions = [eq(agentLessons.agentId, agentId), eq(agentLessons.active, 1)];
+  if (projectId) conditions.push(eq(agentLessons.projectId, projectId));
+
+  const lessons = db.select().from(agentLessons)
+    .where(and(...conditions))
+    .orderBy(desc(agentLessons.createdAt))
+    .limit(5)
+    .all();
+
+  // Get agent score + rank
+  const score = db.select().from(agentScores)
+    .where(and(eq(agentScores.agentId, agentId), eq(agentScores.category, 'overall'))).get();
+
+  // Get project conventions
+  const conventions = projectId
+    ? db.select().from(projectConventions)
+        .where(and(eq(projectConventions.projectId, projectId), eq(projectConventions.active, 1)))
+        .orderBy(desc(projectConventions.evidenceCount))
+        .limit(10)
+        .all()
+    : [];
+
+  // Increment injection counter
+  for (const l of lessons) {
+    db.update(agentLessons).set({ timesInjected: (l.timesInjected || 0) + 1 }).where(eq(agentLessons.id, l.id)).run();
+  }
+
+  // Format for prompt injection
+  const rank = getRank(score?.totalScore || 0);
+  let context = `[AGENT CONTEXT]\nRank: ${rank.title} (score: ${score?.totalScore || 0}, avg: ${(score?.avgScore || 0).toFixed(1)}/5)\n`;
+
+  if (lessons.length > 0) {
+    context += `\nYour recent lessons (learn from past reviews):\n`;
+    for (const l of lessons) {
+      const icon = l.severity === 'high' ? '🔴' : '⚠️';
+      context += `- ${icon} ${l.lesson}\n`;
+    }
+  }
+
+  if (conventions.length > 0) {
+    context += `\n[PROJECT CONVENTIONS]\n`;
+    for (const c of conventions) {
+      context += `- ${c.convention}\n`;
+    }
+  }
+
+  res.json({ context, lessonsCount: lessons.length, conventionsCount: conventions.length, rank });
+});

--- a/packages/control/src/routes/workflows.ts
+++ b/packages/control/src/routes/workflows.ts
@@ -371,7 +371,12 @@ router.post('/:id/run', requireScope('workflows:write'), async (req, res) => {
   try {
     const { triggerType, triggerRef, vars, variables, projectId } = req.body || {};
     const parsedVars = parseJsonField<Record<string, any>>(vars || variables);
-    const run = await startRun(wf, triggerType || 'api', triggerRef, parsedVars, projectId);
+    // Auto-build triggerRef from issue variables if not explicitly provided
+    const resolvedTriggerRef = triggerRef
+      || (parsedVars?.issueRepo && parsedVars?.issueNumber
+        ? `https://github.com/${parsedVars.issueRepo}/issues/${parsedVars.issueNumber}`
+        : undefined);
+    const run = await startRun(wf, triggerType || 'api', resolvedTriggerRef, parsedVars, projectId);
     logAudit(req, 'workflow.run_start', 'workflow_run', run.id, { workflowId: req.params.id });
     res.status(201).json(run);
   } catch (err: any) {

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -211,7 +211,7 @@ export function initWorkflowDispatcher() {
         taskId: opts.taskId,
         from: 'workflow-engine',
         fromRole: 'operator',
-        message: opts.message + worktreeContext + (discoveryContext ?? ''),
+        message: opts.message + worktreeContext + (discoveryContext ?? '') + (opts as any).learningContext || '',
         callbackUrl: `${callbackBaseUrl}/api/tasks/${opts.taskId}/result`,
         projectId: opts.projectId,
         ...(agent.targetAgent && { targetAgent: agent.targetAgent }),

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -646,12 +646,38 @@ async function dispatchStep(
 
   db.update(workflowRuns).set({ currentStep: step.id }).where(eq(workflowRuns.id, run.id)).run();
 
-  
+  // ── Inject learning context (lessons + conventions) ────────────────
+  let learningContext = '';
+  try {
+    const { agentLessons, projectConventions, agentScores } = await import('../db/drizzle-schema.js');
+    // Find the target agent for this step role
+    // Lessons are per-agent, so we inject what we know
+    const agentScore = db.select().from(agentScores)
+      .where(and(eq(agentScores.category, 'overall'))).all();
+
+    // Get project conventions
+    if (run.projectId) {
+      const conventions = db.select().from(projectConventions)
+        .where(and(eq(projectConventions.projectId, run.projectId), eq(projectConventions.active, 1)))
+        .orderBy(desc(projectConventions.evidenceCount))
+        .limit(10)
+        .all();
+      if (conventions.length > 0) {
+        learningContext += '\n\n[PROJECT CONVENTIONS]\n';
+        for (const c of conventions) {
+          learningContext += `- ${c.convention}\n`;
+        }
+      }
+    }
+
+    // Note: Agent-specific lessons will be injected by the agent plugin when it knows
+    // which specific agent is assigned. Here we only inject project-level conventions.
+  } catch { /* learning system not ready yet */ }
 
   try {
     const result = await _dispatchFn({
       role: step.role,
-      message: prompt,
+      message: prompt + learningContext,
       projectId: run.projectId,
       runId: run.id,
       stepId: step.id,


### PR DESCRIPTION
### Learning System (Phase 1+2 of #185)

**Structured reviews with scoring:**
- `POST /api/learning/reviews` — score 1-5, approved/rejected, feedback text
- Auto-updates agent cumulative scores
- Rejected reviews auto-extract lessons into agent memory

**Agent memory (lessons learned):**
- Stored per-agent, sourced from review feedback
- Severity: high (score ≤2) or medium
- Available for prompt injection via `GET /api/learning/lessons/:agentId/context`
- Injection counter tracked

**Project conventions:**
- Manual + extracted patterns ("all routes must use error-handler")
- Injected into workflow step dispatch automatically

**Rank system:**
- Cadet → Lieutenant → Commander → Captain → Admiral
- Based on cumulative review score
- Visible on leaderboard + agent score endpoint

**Prompt injection pipeline:**
- Workflow engine injects project conventions into step prompts
- Agent plugin can fetch formatted lesson context for agent-specific injection
- Format: rank + lessons + conventions in structured block

### Batch fixes
- **#153**: Auto-close GitHub issue — `triggerRef` now auto-built from `issueRepo`+`issueNumber` variables
- **#156**: Verified already fixed (closed issues filtered from triage)
- **#174**: Verified already fixed (per-step repo targeting working)

### Schema
Migration v41 adds 4 tables: `review_records`, `agent_lessons`, `project_conventions`, `agent_scores`

### Verification
- `npx tsc --noEmit` — 0 errors ✅
- 163/163 tests pass ✅