### PR TITLE
feat: convention extraction + skill-level routing (#185 Phase 3+5)

### DIFF
--- a/packages/control/src/routes/learning.ts
+++ b/packages/control/src/routes/learning.ts
@@ -38,6 +38,10 @@ const LEARNING_TOOLS = [
     parameters: [
       { name: 'projectId', type: 'string', description: 'Project ID', required: true },
     ] },
+  { category: 'learning', scope: 'projects:write', name: 'armada_conventions_extract', description: 'Manually trigger convention extraction for a project. Analyzes review feedback and extracts recurring patterns.', method: 'POST', path: '/api/learning/conventions/extract',
+    parameters: [
+      { name: 'projectId', type: 'string', description: 'Project ID', required: true },
+    ] },
 ] as const;
 
 for (const tool of LEARNING_TOOLS) {
@@ -267,6 +271,21 @@ learningRouter.post('/conventions/add', requireScope('projects:write'), (req, re
   }).run();
 
   res.status(201).json({ id, convention });
+});
+
+// POST /api/learning/conventions/extract — manually trigger convention extraction
+learningRouter.post('/conventions/extract', requireScope('projects:write'), async (req, res) => {
+  const { projectId } = req.body;
+  if (!projectId) return res.status(400).json({ error: 'projectId required' });
+
+  try {
+    const { extractConventions } = await import('../services/convention-extractor.js');
+    const result = await extractConventions(projectId);
+    res.json(result);
+  } catch (err) {
+    console.error('[learning] Convention extraction failed:', err);
+    res.status(500).json({ error: 'Extraction failed', message: (err as Error).message });
+  }
 });
 
 // GET /api/learning/leaderboard — agent score leaderboard

--- a/packages/control/src/services/convention-extractor.ts
+++ b/packages/control/src/services/convention-extractor.ts
@@ -1,0 +1,237 @@
+/**
+ * Convention extraction service — analyzes review feedback and extracts
+ * recurring patterns as project conventions.
+ * Part of Learning System Phase 3 (#185).
+ */
+
+import { getDrizzle } from '../db/drizzle.js';
+import { reviewRecords, workflowRuns, projectConventions } from '../db/drizzle-schema.js';
+import { eq, and, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+
+interface ExtractionResult {
+  newConventions: number;
+  updatedConventions: number;
+  totalReviewsAnalysed: number;
+}
+
+// ── Extraction tracker ─────────────────────────────────────────────
+// In-memory tracker for when to run extraction per project
+const projectExtractionTrackers = new Map<string, { completedRuns: number; lastExtractionAt: string }>();
+
+/**
+ * Check if convention extraction should run for this project.
+ * Runs every 5 completed workflow runs.
+ */
+export function shouldExtractConventions(projectId: string): boolean {
+  const tracker = projectExtractionTrackers.get(projectId) || { completedRuns: 0, lastExtractionAt: '' };
+  tracker.completedRuns++;
+  projectExtractionTrackers.set(projectId, tracker);
+
+  if (tracker.completedRuns >= 5) {
+    // Reset counter
+    tracker.completedRuns = 0;
+    tracker.lastExtractionAt = new Date().toISOString();
+    return true;
+  }
+  return false;
+}
+
+// ── Text normalization ──────────────────────────────────────────────
+
+/**
+ * Normalize text for comparison — lowercase, strip punctuation, trim whitespace.
+ */
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Split text into sentences (simple approach — split on . ! ? followed by space).
+ */
+function splitIntoSentences(text: string): string[] {
+  return text
+    .split(/[.!?]+\s+/)
+    .map(s => s.trim())
+    .filter(s => s.length > 10); // Skip very short fragments
+}
+
+/**
+ * Calculate Jaccard similarity between two sets of words.
+ * Returns value between 0 (no overlap) and 1 (identical).
+ */
+function jaccardSimilarity(a: string, b: string): number {
+  const wordsA = new Set(a.split(/\s+/));
+  const wordsB = new Set(b.split(/\s+/));
+  
+  const intersection = new Set([...wordsA].filter(w => wordsB.has(w)));
+  const union = new Set([...wordsA, ...wordsB]);
+  
+  return intersection.size / union.size;
+}
+
+/**
+ * Find recurring patterns in feedback sentences.
+ * Returns sentences that appear (or are very similar) across 3+ reviews.
+ */
+function findRecurringPatterns(feedbackTexts: string[]): Map<string, number> {
+  // Extract all sentences from all feedback
+  const allSentences = feedbackTexts.flatMap(text => splitIntoSentences(text));
+  const normalizedSentences = allSentences.map(normalizeText);
+  
+  // Group similar sentences
+  const clusters = new Map<string, { original: string; count: number; normalized: string }>();
+  
+  for (let i = 0; i < normalizedSentences.length; i++) {
+    const normalized = normalizedSentences[i];
+    const original = allSentences[i];
+    
+    // Check if this sentence matches any existing cluster
+    let matched = false;
+    for (const [key, cluster] of clusters.entries()) {
+      if (jaccardSimilarity(normalized, cluster.normalized) > 0.5) {
+        cluster.count++;
+        matched = true;
+        break;
+      }
+    }
+    
+    if (!matched) {
+      clusters.set(original, { original, count: 1, normalized });
+    }
+  }
+  
+  // Return only patterns that appear 3+ times
+  const recurring = new Map<string, number>();
+  for (const [_key, cluster] of clusters.entries()) {
+    if (cluster.count >= 3) {
+      recurring.set(cluster.original, cluster.count);
+    }
+  }
+  
+  return recurring;
+}
+
+/**
+ * Check if a convention already exists (fuzzy match).
+ * Returns the existing convention ID if found, null otherwise.
+ */
+function findExistingConvention(projectId: string, conventionText: string): string | null {
+  const db = getDrizzle();
+  const existing = db.select()
+    .from(projectConventions)
+    .where(and(
+      eq(projectConventions.projectId, projectId),
+      eq(projectConventions.active, 1)
+    ))
+    .all();
+  
+  const normalized = normalizeText(conventionText);
+  
+  for (const conv of existing) {
+    if (jaccardSimilarity(normalized, normalizeText(conv.convention)) > 0.7) {
+      return conv.id;
+    }
+  }
+  
+  return null;
+}
+
+// ── Main extraction function ────────────────────────────────────────
+
+/**
+ * Extract conventions from review feedback for a project.
+ * Analyzes rejected reviews, finds recurring patterns, and creates/updates conventions.
+ */
+export async function extractConventions(projectId: string): Promise<ExtractionResult> {
+  console.log(`[convention-extractor] Running extraction for project ${projectId}`);
+  
+  const db = getDrizzle();
+  
+  // 1. Query all review records for this project (join through workflow_runs)
+  const reviews = db.select({
+    reviewId: reviewRecords.id,
+    result: reviewRecords.result,
+    feedback: reviewRecords.feedback,
+    runId: reviewRecords.runId,
+  })
+    .from(reviewRecords)
+    .innerJoin(workflowRuns, eq(reviewRecords.runId, workflowRuns.id))
+    .where(eq(workflowRuns.projectId, projectId))
+    .all();
+  
+  console.log(`[convention-extractor] Found ${reviews.length} total reviews`);
+  
+  // 2. Filter for rejected reviews with feedback
+  const rejectedReviews = reviews.filter(r => 
+    r.result === 'rejected' && 
+    r.feedback && 
+    r.feedback.length > 10
+  );
+  
+  console.log(`[convention-extractor] ${rejectedReviews.length} rejected reviews with feedback`);
+  
+  if (rejectedReviews.length < 3) {
+    console.log(`[convention-extractor] Not enough rejected reviews to extract patterns`);
+    return {
+      newConventions: 0,
+      updatedConventions: 0,
+      totalReviewsAnalysed: reviews.length,
+    };
+  }
+  
+  // 3. Extract recurring patterns
+  const feedbackTexts = rejectedReviews.map(r => r.feedback!);
+  const patterns = findRecurringPatterns(feedbackTexts);
+  
+  console.log(`[convention-extractor] Found ${patterns.size} recurring patterns`);
+  
+  let newConventions = 0;
+  let updatedConventions = 0;
+  
+  // 4. For each pattern, check if convention exists or create new one
+  for (const [pattern, evidenceCount] of patterns.entries()) {
+    const existingId = findExistingConvention(projectId, pattern);
+    
+    if (existingId) {
+      // Update evidence count
+      const existing = db.select()
+        .from(projectConventions)
+        .where(eq(projectConventions.id, existingId))
+        .get();
+      
+      if (existing) {
+        db.update(projectConventions)
+          .set({ evidenceCount: (existing.evidenceCount || 0) + evidenceCount })
+          .where(eq(projectConventions.id, existingId))
+          .run();
+        updatedConventions++;
+        console.log(`[convention-extractor] Updated convention ${existingId}: "${pattern.slice(0, 60)}..."`);
+      }
+    } else {
+      // Create new convention
+      const id = randomUUID();
+      db.insert(projectConventions).values({
+        id,
+        projectId,
+        convention: pattern,
+        source: 'extracted',
+        evidenceCount,
+      }).run();
+      newConventions++;
+      console.log(`[convention-extractor] Created convention ${id}: "${pattern.slice(0, 60)}..."`);
+    }
+  }
+  
+  console.log(`[convention-extractor] Complete: ${newConventions} new, ${updatedConventions} updated`);
+  
+  return {
+    newConventions,
+    updatedConventions,
+    totalReviewsAnalysed: reviews.length,
+  };
+}

--- a/packages/control/src/services/workflow-dispatcher.ts
+++ b/packages/control/src/services/workflow-dispatcher.ts
@@ -29,13 +29,52 @@ const _worktreeTasks = new Map<string, WorktreeTaskEntry>();
  * Find the least busy running agent with the given role.
  * Uses capacity data from the health monitor for load balancing:
  * sorted by healthy first, then lowest taskCount, then lowest responseMs.
+ * 
+ * If multiple agents match, prefer the one with higher review scores for this role.
  *
  * When the agent belongs to a multi-agent instance, returns the instance URL
  * plus targetAgent so the receiving instance can route correctly.
  */
-function findAgentByRole(role: string): { name: string; url: string; targetAgent?: string } | null {
+async function findAgentByRole(role: string, category?: string): Promise<{ name: string; url: string; targetAgent?: string } | null> {
   const candidates = getAgentsByRoleWithCapacity(role);
   if (candidates.length === 0) return null;
+
+  // If multiple candidates exist and we have a category, prefer higher-scoring agents
+  if (candidates.length > 1 && category) {
+    const { getDrizzle } = await import('../db/drizzle.js');
+    const { agentScores } = await import('../db/drizzle-schema.js');
+    const { eq, and } = await import('drizzle-orm');
+    
+    const db = getDrizzle();
+    const cat = category || role; // Use role as fallback category
+    
+    // Fetch scores for all candidates
+    const candidateNames = candidates.map(c => c.name);
+    const scores = db.select()
+      .from(agentScores)
+      .where(eq(agentScores.category, cat))
+      .all();
+    
+    // Build score map
+    const scoreMap = new Map<string, number>();
+    for (const score of scores) {
+      if (candidateNames.includes(score.agentId)) {
+        scoreMap.set(score.agentId, score.avgScore || 0);
+      }
+    }
+    
+    // Sort candidates: first by score (desc), then by capacity
+    candidates.sort((a, b) => {
+      const scoreA = scoreMap.get(a.name) || 0;
+      const scoreB = scoreMap.get(b.name) || 0;
+      
+      if (scoreA !== scoreB) return scoreB - scoreA; // Higher score first
+      
+      // Fall back to capacity sort
+      if (a.taskCount !== b.taskCount) return a.taskCount - b.taskCount;
+      return a.responseMs - b.responseMs;
+    });
+  }
 
   // Already sorted by capacity (healthy first, lowest taskCount, lowest responseMs)
   return {
@@ -51,7 +90,8 @@ function findAgentByRole(role: string): { name: string; url: string; targetAgent
  */
 export function initWorkflowDispatcher() {
   setWorkflowDispatcher(async (opts) => {
-    const agent = findAgentByRole(opts.role);
+    // Use role as category for skill-level routing (Phase 3 enhancement)
+    const agent = await findAgentByRole(opts.role, opts.role);
     // Resolve project UUID → project name (tasks table stores name as project_id)
     const projectName = opts.projectId
       ? (projectsRepo.get(opts.projectId)?.name ?? opts.projectId)

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -542,6 +542,16 @@ async function advanceRun(
       });
     }
 
+    // ── Run convention extraction every 5 completed runs ────────────────
+    if (finalStatus === 'completed' && run.projectId) {
+      const { shouldExtractConventions, extractConventions } = await import('./convention-extractor.js');
+      if (shouldExtractConventions(run.projectId)) {
+        extractConventions(run.projectId).catch((err: Error) => {
+          console.error('[convention-extractor]', err.message);
+        });
+      }
+    }
+
     if (_notifyFn) {
       // For failed runs, include details about which step failed and why
       const failedStepRun = finalStatus === 'failed'


### PR DESCRIPTION
Part of #185

### Convention Extraction (Phase 3)
- New service: `convention-extractor.ts` (237 lines)
- Analyses rejected review feedback for recurring patterns
- Jaccard similarity (>0.5) to group similar feedback sentences
- Patterns appearing in 3+ reviews become conventions
- Fuzzy dedup (>0.7) against existing conventions
- Auto-triggers every 5 completed runs per project
- Manual trigger: `POST /api/learning/conventions/extract`
- New tool: `armada_conventions_extract`

### Skill-Level Routing (Phase 5 lite)
- `findAgentByRole` now considers review scores
- Multiple candidates → prefer higher avg score for the category
- Falls back to capacity-based selection if scores equal
- Uses role as category if no explicit category

0 TS errors, 163 tests pass.