### PR TITLE
feat: prompt evolution tracking (#185 Phase 4)

### DIFF
--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -310,6 +310,7 @@ export const workflowStepRuns = sqliteTable('workflow_step_runs', {
   completedAt: text('completed_at'),
   retryConfigJson: text('retry_config'),
   telegramNotificationsJson: text('telegram_notifications_json'),
+  promptHash: text('prompt_hash').notNull().default(''),
 });
 
 // ── users ────────────────────────────────────────────────────────────
@@ -744,4 +745,14 @@ export const agentScores = sqliteTable('agent_scores', {
   reviewCount: integer('review_count').default(0),
   avgScore: real('avg_score').default(0),
   lastUpdated: text('last_updated').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export const promptVersions = sqliteTable('prompt_versions', {
+  id: text('id').primaryKey(),
+  workflowId: text('workflow_id').notNull(),
+  stepId: text('step_id').notNull(),
+  version: integer('version').notNull().default(1),
+  promptTemplate: text('prompt_template').notNull(),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  retiredAt: text('retired_at'),
 });

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -592,6 +592,32 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 42,
+    description: 'Create prompt_versions table for tracking prompt evolution (#185 Phase 4)',
+    run(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS prompt_versions (
+          id TEXT PRIMARY KEY,
+          workflow_id TEXT NOT NULL,
+          step_id TEXT NOT NULL,
+          version INTEGER NOT NULL DEFAULT 1,
+          prompt_template TEXT NOT NULL,
+          created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+          retired_at TEXT,
+          UNIQUE(workflow_id, step_id, version)
+        );
+        CREATE INDEX IF NOT EXISTS idx_prompt_versions_workflow ON prompt_versions(workflow_id, step_id);
+      `);
+    },
+  },
+  {
+    version: 43,
+    description: 'Add prompt_hash column to workflow_step_runs (#185 Phase 4)',
+    sql: [
+      "ALTER TABLE workflow_step_runs ADD COLUMN prompt_hash TEXT DEFAULT ''",
+    ],
+  },
 ];
 
 /**

--- a/packages/control/src/routes/analytics.ts
+++ b/packages/control/src/routes/analytics.ts
@@ -11,6 +11,10 @@ import {
   getAgentStats,
   getRecentRuns,
 } from '../services/workflow-metrics.js';
+import {
+  getPromptPerformance,
+  getAllStepPromptPerformance,
+} from '../services/prompt-performance.js';
 
 export const analyticsRouter = Router();
 
@@ -66,6 +70,29 @@ const ANALYTICS_TOOLS = [
     path: '/api/analytics/runs/recent',
     parameters: [
       { name: 'limit', type: 'number', description: 'Number of runs to return (default 20)' },
+    ],
+  },
+  {
+    category: 'analytics',
+    scope: 'workflows:read',
+    name: 'armada_prompt_performance',
+    description: 'Get prompt version performance for all steps in a workflow. Shows which prompt versions correlate with higher review scores.',
+    method: 'GET',
+    path: '/api/analytics/prompts/:workflowId',
+    parameters: [
+      { name: 'workflowId', type: 'string', description: 'Workflow ID', required: true },
+    ],
+  },
+  {
+    category: 'analytics',
+    scope: 'workflows:read',
+    name: 'armada_prompt_performance_step',
+    description: 'Get detailed prompt version performance for a specific workflow step.',
+    method: 'GET',
+    path: '/api/analytics/prompts/:workflowId/:stepId',
+    parameters: [
+      { name: 'workflowId', type: 'string', description: 'Workflow ID', required: true },
+      { name: 'stepId', type: 'string', description: 'Step ID', required: true },
     ],
   },
 ] as const;
@@ -141,5 +168,29 @@ analyticsRouter.get('/runs/recent', requireScope('workflows:read'), (req, res) =
   } catch (error: any) {
     console.error('Error fetching recent runs:', error);
     res.status(500).json({ error: error.message || 'Failed to fetch recent runs' });
+  }
+});
+
+// GET /api/analytics/prompts/:workflowId — prompt version performance for all steps
+analyticsRouter.get('/prompts/:workflowId', requireScope('workflows:read'), (req, res) => {
+  try {
+    const { workflowId } = req.params;
+    const stats = getAllStepPromptPerformance(workflowId);
+    res.json(stats);
+  } catch (error: any) {
+    console.error('Error fetching prompt performance:', error);
+    res.status(500).json({ error: error.message || 'Failed to fetch prompt performance' });
+  }
+});
+
+// GET /api/analytics/prompts/:workflowId/:stepId — detailed performance for a specific step
+analyticsRouter.get('/prompts/:workflowId/:stepId', requireScope('workflows:read'), (req, res) => {
+  try {
+    const { workflowId, stepId } = req.params;
+    const stats = getPromptPerformance(workflowId, stepId);
+    res.json(stats);
+  } catch (error: any) {
+    console.error('Error fetching step prompt performance:', error);
+    res.status(500).json({ error: error.message || 'Failed to fetch step prompt performance' });
   }
 });

--- a/packages/control/src/services/prompt-performance.ts
+++ b/packages/control/src/services/prompt-performance.ts
@@ -1,0 +1,192 @@
+/**
+ * Prompt Performance Tracking Service (#185 Phase 4)
+ * 
+ * Track which prompt versions correlate with higher review scores,
+ * enabling data-driven prompt improvement.
+ */
+
+import { getDb } from '../db/index.js';
+import { createHash } from 'node:crypto';
+import { nanoid } from 'nanoid';
+
+/**
+ * Hash a prompt template to detect changes.
+ * Returns the first 16 characters of the SHA-256 hash.
+ */
+export function hashPrompt(promptTemplate: string): string {
+  return createHash('sha256').update(promptTemplate).digest('hex').slice(0, 16);
+}
+
+/**
+ * Snapshot the current prompt template as a new version.
+ * Called when a workflow step's prompt changes.
+ * 
+ * @param workflowId - The workflow ID
+ * @param stepId - The step ID
+ * @param promptTemplate - The full prompt template text
+ */
+export function snapshotPromptVersion(
+  workflowId: string,
+  stepId: string,
+  promptTemplate: string
+): void {
+  const db = getDb();
+  const promptHash = hashPrompt(promptTemplate);
+
+  // Check if this exact prompt already exists
+  const existing = db
+    .prepare(
+      `SELECT id FROM prompt_versions 
+       WHERE workflow_id = ? AND step_id = ? AND prompt_template = ?`
+    )
+    .get(workflowId, stepId, promptTemplate) as { id: string } | undefined;
+
+  if (existing) {
+    // Prompt hasn't changed, no need to create a new version
+    return;
+  }
+
+  // Get the next version number
+  const latestVersion = db
+    .prepare(
+      `SELECT MAX(version) as maxVer FROM prompt_versions 
+       WHERE workflow_id = ? AND step_id = ?`
+    )
+    .get(workflowId, stepId) as { maxVer: number | null } | undefined;
+
+  const nextVersion = (latestVersion?.maxVer ?? 0) + 1;
+
+  // Insert new version
+  db.prepare(
+    `INSERT INTO prompt_versions (id, workflow_id, step_id, version, prompt_template, created_at)
+     VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
+  ).run(nanoid(), workflowId, stepId, nextVersion, promptTemplate);
+}
+
+/**
+ * Record which prompt version was used for a step run.
+ * Called when a step is dispatched.
+ * 
+ * @param runId - The workflow run ID
+ * @param stepId - The step ID
+ * @param workflowId - The workflow ID
+ * @param promptHash - Hash of the prompt template used
+ */
+export function recordPromptUsage(
+  runId: string,
+  stepId: string,
+  workflowId: string,
+  promptHash: string
+): void {
+  const db = getDb();
+
+  // Update the step run with the prompt hash
+  db.prepare(
+    `UPDATE workflow_step_runs 
+     SET prompt_hash = ? 
+     WHERE run_id = ? AND step_id = ?`
+  ).run(promptHash, runId, stepId);
+}
+
+/**
+ * Performance stats for a single prompt version
+ */
+export interface PromptVersionPerformance {
+  version: number;
+  promptHash: string;
+  avgScore: number;
+  totalUses: number;
+  totalReviews: number;
+  retiredAt: string | null;
+}
+
+/**
+ * Get performance stats for each prompt version of a step.
+ * Correlates prompt versions with review scores.
+ * 
+ * @param workflowId - The workflow ID
+ * @param stepId - The step ID
+ * @returns Array of performance stats per version
+ */
+export function getPromptPerformance(
+  workflowId: string,
+  stepId: string
+): PromptVersionPerformance[] {
+  const db = getDb();
+
+  // First, get all prompt versions for this step
+  const versions = db
+    .prepare(
+      `SELECT version, prompt_template, retired_at 
+       FROM prompt_versions 
+       WHERE workflow_id = ? AND step_id = ? 
+       ORDER BY version DESC`
+    )
+    .all(workflowId, stepId) as Array<{
+    version: number;
+    prompt_template: string;
+    retired_at: string | null;
+  }>;
+
+  // For each version, compute the hash and get stats
+  return versions.map(v => {
+    const promptHash = hashPrompt(v.prompt_template);
+
+    // Get usage and review stats for this prompt hash
+    const stats = db
+      .prepare(
+        `SELECT 
+           COUNT(DISTINCT wsr.id) as total_uses,
+           COUNT(DISTINCT rr.id) as total_reviews,
+           COALESCE(AVG(rr.score), 0) as avg_score
+         FROM workflow_step_runs wsr
+         LEFT JOIN review_records rr 
+           ON rr.run_id = wsr.run_id 
+           AND rr.step_id = wsr.step_id
+         WHERE wsr.prompt_hash = ? 
+           AND wsr.step_id = ?`
+      )
+      .get(promptHash, stepId) as {
+      total_uses: number;
+      total_reviews: number;
+      avg_score: number;
+    } | undefined;
+
+    return {
+      version: v.version,
+      promptHash,
+      avgScore: stats?.avg_score ?? 0,
+      totalUses: stats?.total_uses ?? 0,
+      totalReviews: stats?.total_reviews ?? 0,
+      retiredAt: v.retired_at,
+    };
+  });
+}
+
+/**
+ * Get performance stats for all steps in a workflow.
+ * Returns a map of stepId -> performance stats.
+ * 
+ * @param workflowId - The workflow ID
+ * @returns Map of step ID to performance stats
+ */
+export function getAllStepPromptPerformance(
+  workflowId: string
+): Record<string, PromptVersionPerformance[]> {
+  const db = getDb();
+
+  // Get all unique step IDs for this workflow
+  const steps = db
+    .prepare(
+      `SELECT DISTINCT step_id FROM prompt_versions WHERE workflow_id = ?`
+    )
+    .all(workflowId) as Array<{ step_id: string }>;
+
+  const result: Record<string, PromptVersionPerformance[]> = {};
+
+  for (const step of steps) {
+    result[step.step_id] = getPromptPerformance(workflowId, step.step_id);
+  }
+
+  return result;
+}

--- a/packages/control/src/services/workflow-engine.ts
+++ b/packages/control/src/services/workflow-engine.ts
@@ -21,6 +21,7 @@ import { getArtifactContextBlock } from '../routes/workflow-artifacts.js';
 import { projectsRepo, agentsRepo, instancesRepo } from '../repositories/index.js';
 import { getNodeClient } from '../infrastructure/node-client.js';
 import { eventBus } from '../infrastructure/event-bus.js';
+import { hashPrompt } from './prompt-performance.js';
 
 // Types — mirror shared package types locally to avoid build ordering issues
 interface WorkflowStep {
@@ -655,10 +656,11 @@ async function dispatchStep(
   const prompt = contextWithArtifacts + '\n\n' + resolvedPrompt;
   const taskId = `wf-${run.id.slice(0, 8)}-${step.id}`;
 
-  // Mark step as running and store the resolved prompt
+  // Mark step as running and store the resolved prompt + prompt hash
   const db = getDrizzle();
+  const promptHash = hashPrompt(prompt);
   db.run(sql`
-    UPDATE workflow_step_runs SET status = 'running', started_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), task_id = ${taskId}, input_json = ${JSON.stringify({ prompt })}
+    UPDATE workflow_step_runs SET status = 'running', started_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), task_id = ${taskId}, input_json = ${JSON.stringify({ prompt })}, prompt_hash = ${promptHash}
     WHERE id = ${stepRun.id}
   `);
 
@@ -1678,6 +1680,14 @@ export function updateWorkflow(id: string, params: UpdateWorkflowParams): (Workf
       waitFor: s.waitFor || (s as any).dependsOn || (s as any).dependencies || [],
     }));
     db.update(workflowsTable).set({ stepsJson: JSON.stringify(normalised) }).where(eq(workflowsTable.id, id)).run();
+
+    // Snapshot prompt versions for changed steps (#185 Phase 4)
+    const { snapshotPromptVersion } = require('./prompt-performance.js');
+    for (const step of normalised) {
+      if (step.prompt) {
+        snapshotPromptVersion(id, step.id, step.prompt);
+      }
+    }
   }
   if (params.enabled !== undefined) db.update(workflowsTable).set({ enabled: params.enabled ? 1 : 0 }).where(eq(workflowsTable.id, id)).run();
 


### PR DESCRIPTION
Final phase of the learning system (#185).

### New
- `prompt_versions` table — snapshots prompt templates with version numbers
- `prompt_hash` on step runs — links each run to its prompt version
- `prompt-performance.ts` service — correlates prompt versions with review scores
- Auto-snapshot on workflow update (detects prompt changes via SHA-256 hash)
- Hash stored on step dispatch for tracking

### API
- `GET /api/analytics/prompts/:workflowId` — all steps' prompt performance
- `GET /api/analytics/prompts/:workflowId/:stepId` — detailed per-step

### Learning System Complete 🎓
- Phase 1 ✅ Structured reviews + scoring
- Phase 2 ✅ Agent lessons + memory
- Phase 3 ✅ Convention extraction
- Phase 4 ✅ Prompt evolution (this PR)
- Phase 5 ✅ Skill-level routing

0 TS errors, 163 tests pass.