### PR TITLE
fix: absolute paths for SOUL.md/AGENTS.md writes in redeploy (#206)

### DIFF
--- a/packages/control/src/services/agent-manager.ts
+++ b/packages/control/src/services/agent-manager.ts
@@ -153,10 +153,11 @@ class AgentManagerImpl implements AgentManager {
     };
 
     // Build the agent config entry from template
+    // workspace should be the container-side absolute path (relative to /home/node/.openclaw)
     const agentConfig: Record<string, any> = {
       id: agent.name,
       name: agent.name,
-      workspace: `workspace/agents/${agent.name}`,
+      workspace: 'workspace', // This resolves to /home/node/.openclaw/workspace inside the container
       model: resolveTemplateModel(template),
       tools: undefined as any,
       identity: { name: agent.name },
@@ -168,12 +169,13 @@ class AgentManagerImpl implements AgentManager {
     // Update workspace files (SOUL.md, AGENTS.md, gitconfig) — these don't need restart
     await lifecycle.updateAgent(agent.instanceId, agentConfig);
 
-    const workspaceBase = `workspace/agents/${agent.name}`;
+    // Write files to absolute paths within the container workspace
+    // These paths should resolve to /home/node/.openclaw/workspace inside the container
     if (template.soul) {
-      await lifecycle.writeInstanceFile(agent.instanceId, `${workspaceBase}/SOUL.md`, resolveVariables(template.soul, vars));
+      await lifecycle.writeInstanceFile(agent.instanceId, `/home/node/.openclaw/workspace/SOUL.md`, resolveVariables(template.soul, vars));
     }
     if (template.agents) {
-      await lifecycle.writeInstanceFile(agent.instanceId, `${workspaceBase}/AGENTS.md`, resolveVariables(template.agents, vars));
+      await lifecycle.writeInstanceFile(agent.instanceId, `/home/node/.openclaw/workspace/AGENTS.md`, resolveVariables(template.agents, vars));
     }
 
     // Stage the update mutation — DB record stays as-is until changeset is applied

--- a/packages/node/src/handlers/files.ts
+++ b/packages/node/src/handlers/files.ts
@@ -54,11 +54,37 @@ async function handleFileRead(msg: CommandMessage): Promise<ResponseMessage> {
 }
 
 async function handleFileWrite(msg: CommandMessage): Promise<ResponseMessage> {
-  const { path, content, encoding = 'utf8' } = msg.params as { path: string; content: string; encoding?: 'utf8' | 'base64' };
+  const { instance, path, content, encoding = 'utf8' } = msg.params as { 
+    instance?: string; 
+    path: string; 
+    content: string; 
+    encoding?: 'utf8' | 'base64' 
+  };
   if (!path || content === undefined) {
     return { type: 'response', id: msg.id, status: 'error', error: 'path and content are required', code: WsErrorCode.UNKNOWN };
   }
-  const resolved = validatePath(path);
+  
+  let resolved: string;
+  if (instance) {
+    // Writing to an instance data volume
+    // Path should be absolute within the container (e.g., /home/node/.openclaw/workspace/SOUL.md)
+    // We need to map it to the host-side volume path
+    const instanceDataDir = `${ARMADA_INSTANCES_DIR}/${instance}`;
+    
+    // Strip /home/node/.openclaw prefix if present, since that's the container mount point
+    const containerPrefix = '/home/node/.openclaw';
+    const relativePath = path.startsWith(containerPrefix) 
+      ? path.slice(containerPrefix.length)
+      : path;
+    
+    // Ensure path doesn't start with / after prefix removal
+    const cleanPath = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+    resolved = resolve(instanceDataDir, cleanPath);
+  } else {
+    // Writing to DATA_DIR (legacy behavior)
+    resolved = validatePath(path);
+  }
+  
   // Create parent directories if needed
   const dir = resolved.substring(0, resolved.lastIndexOf('/'));
   await mkdir(dir, { recursive: true });


### PR DESCRIPTION
Fixes the recursive nesting bug where redeploy created paths like:
`/app/agents/forge/agents/forge/agents/forge/.../SOUL.md`

### Root Cause
`writeInstanceFile` used relative paths (`workspace/agents/{name}/SOUL.md`) which resolved against the agent's CWD, appending another nesting level on each redeploy.

### Fix
- `agent-manager.ts`: absolute path `/home/node/.openclaw/workspace/SOUL.md`
- `agent-manager.ts`: workspace config `workspace` not `workspace/agents/{name}`  
- `files.ts`: node handler maps container paths to host volumes correctly

0 TS errors, 163 tests pass.