### PR TITLE
fix: template updates flow through changeset pipeline properly (#209)

### DIFF
--- a/packages/control/src/routes/templates.ts
+++ b/packages/control/src/routes/templates.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { randomUUID } from 'node:crypto';
 import { requireScope } from '../middleware/scopes.js';
-import { templatesRepo } from '../repositories/index.js';
+import { templatesRepo, agentsRepo } from '../repositories/index.js';
 import { isValidName, isValidMemory, isValidCpus } from '../utils/validate.js';
 import { registerToolDef } from '../utils/tool-registry.js';
 import { logActivity } from '../services/activity-service.js';
@@ -183,10 +183,23 @@ router.put('/:id', requireScope('templates:write'), (req, res, next) => {
     // Update working copy for UI diff preview
     workingCopy.update('template', req.params.id, body);
     
-    // Stage a mutation so changesets can pick it up
+    // Stage a template mutation for the template record itself
     mutationService.stage('template', 'update', body, req.params.id);
     
-    logActivity({ eventType: 'template.updated', detail: `Template "${existing.name}" staged for update` });
+    // Find agents using this template and stage agent mutations for file writes
+    // This ensures the changeset system can plan workspace file updates
+    const agents = agentsRepo.getAll().filter(a => a.templateId === req.params.id);
+    for (const agent of agents) {
+      // Stage agent update mutation with soul/agents content
+      // Include instanceId so the changeset knows which instance to target
+      mutationService.stage('agent', 'update', {
+        soul: body.soul,
+        agentsMd: body.agents,
+        instanceId: agent.instanceId,
+      }, agent.id);
+    }
+    
+    logActivity({ eventType: 'template.updated', detail: `Template "${existing.name}" staged for update, ${agents.length} agent(s) queued for sync` });
     eventBus.emit('template.updated', { templateId: req.params.id });
     logAudit(req, 'template.update', 'template', req.params.id, { name: existing.name });
     res.json({ ok: true, action: 'update', message: 'Staged — create and apply a changeset to commit' });

--- a/packages/control/src/services/changeset-service.ts
+++ b/packages/control/src/services/changeset-service.ts
@@ -6,7 +6,7 @@ import { getDrizzle } from '../db/drizzle.js';
 import { getDb } from '../db/index.js';
 import { getCurrentSchemaVersion } from '../db/migrations.js';
 import { changesets, changesetOperations } from '../db/drizzle-schema.js';
-import { instancesRepo, pendingMutationRepo, templatesRepo } from '../repositories/index.js';
+import { instancesRepo, pendingMutationRepo, templatesRepo, agentsRepo } from '../repositories/index.js';
 import { configDiffService } from './config-diff.js';
 import { eventBus } from '../infrastructure/event-bus.js';
 import { operationManager } from '../infrastructure/operations.js';
@@ -15,7 +15,7 @@ import { applyChangeset, retryFailedInstances } from './changeset-apply.js';
 import { computeMutationDiffs } from './diff-computer.js';
 import { buildStepsForInstance, dagToSteps } from './step-planner.js';
 import { analyseChangesetImpact } from './changeset-impact.js';
-import type { StateChange, ChangesetPlan, Changeset, ArmadaInstance } from '@coderage-labs/armada-shared';
+import type { StateChange, ChangesetPlan, Changeset, ArmadaInstance, Agent } from '@coderage-labs/armada-shared';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -198,6 +198,17 @@ export function createChangesetService(): ChangesetService {
           if (instMutation) {
             instanceMap.set(instanceId, { instanceId, instanceName: instMutation.payload?.name || instanceId });
           }
+        }
+      }
+    }
+
+    // Template mutations — find affected instances via agents using this template
+    for (const m of allMutations.filter(m => m.entityType === 'template')) {
+      const agents = agentsRepo.getAll().filter((a: Agent) => a.templateId === m.entityId);
+      for (const agent of agents) {
+        const inst = instancesRepo.getById(agent.instanceId);
+        if (inst && !instanceMap.has(inst.id)) {
+          instanceMap.set(inst.id, { instanceId: inst.id, instanceName: inst.name });
         }
       }
     }

--- a/packages/control/src/services/mutation-executor.ts
+++ b/packages/control/src/services/mutation-executor.ts
@@ -7,6 +7,7 @@ import {
   pluginLibraryRepo,
   instancesRepo,
   assignmentRepo,
+  templatesRepo,
 } from '../repositories/index.js';
 import type { PendingMutation } from '../repositories/pending-mutation-repo.js';
 import { pluginManager } from './plugin-manager.js';
@@ -154,6 +155,16 @@ function executeMutation(mutation: PendingMutation): void {
         pluginManager.update(entityId, payload as any);
       } else if (action === 'delete' && entityId) {
         pluginManager.delete(entityId);
+      }
+      break;
+
+    case 'template':
+      if (action === 'create' && entityId) {
+        templatesRepo.create(payload as any);
+      } else if (action === 'update' && entityId) {
+        templatesRepo.update(entityId, payload as any);
+      } else if (action === 'delete' && entityId) {
+        templatesRepo.remove(entityId);
       }
       break;
 


### PR DESCRIPTION
Closes #209

### Root cause
Template mutations weren't handled by the changeset system:
- `preview()` didn't resolve template entity type to instances
- `mutation-executor` had no template case
- Template changes sat in pending_mutations but were invisible to changesets

### Fix (3 files, 40 lines)

**templates.ts** — route stages BOTH a template mutation (for DB record) AND agent mutations (for workspace file writes). No direct DB writes.

**changeset-service.ts** — `preview()` now resolves template mutations to affected instances via agents using that template.

**mutation-executor.ts** — handles template create/update/delete through `templatesRepo`.

### Full pipeline
```
armada_template_update → stages template + agent mutations
POST /api/changesets → preview finds affected instances
POST /api/changesets/:id/apply → executor commits template to DB + writes agent files
armada_redeploy → reads committed values, writes per-agent SOUL.md/AGENTS.md
```

Everything through the pipeline. No shortcuts.

0 TS errors, 163 tests pass.