### PR TITLE
fix: template-only changesets skip config_version bump and staleness check (#212)

### DIFF
--- a/packages/control/src/services/changeset-service.ts
+++ b/packages/control/src/services/changeset-service.ts
@@ -223,30 +223,57 @@ export function createChangesetService(): ChangesetService {
     const instanceOps = targetInstances.map(inst => {
       const dag = buildStepsForInstance(inst.instanceId, currentVersion);
       const steps = dagToSteps(dag);
-      // Each stale instance gets the full set of global changes
-      const instChanges: StateChange[] = currentSnapshot.providers.length > 0 ||
-        currentSnapshot.models.length > 0 ||
-        currentSnapshot.plugins.length > 0
-        ? [
-            {
-              instanceId: inst.instanceId,
-              type: 'config' as const,
-              field: 'config_version',
-              current: null,
-              desired: currentVersion,
-              requiresRestart: true,
-            },
-          ]
-        : [
-            {
-              instanceId: inst.instanceId,
-              type: 'config' as const,
-              field: 'config_version',
-              current: null,
-              desired: currentVersion,
-              requiresRestart: true,
-            },
-          ];
+      
+      // Check if ALL mutations for this instance are "file-only" (soul/agents text changes)
+      // Template mutations that only touch soul/agents are file-only
+      // Agent mutations that only touch soul/agentsMd/instanceId are file-only
+      const instanceMutations = allMutations.filter(m => {
+        if (m.entityType === 'template') {
+          // Template affects this instance if any agent on this instance uses the template
+          const templateAgents = agentsRepo.getAll().filter((a: Agent) => a.templateId === m.entityId);
+          return templateAgents.some(a => a.instanceId === inst.instanceId);
+        }
+        if (m.entityType === 'agent') {
+          return m.payload?.instanceId === inst.instanceId;
+        }
+        if (m.entityType === 'instance') {
+          return m.entityId === inst.instanceId;
+        }
+        // Global mutations (provider, model, api_key, plugin) affect all instances in scope
+        if (['provider', 'model', 'api_key', 'plugin'].includes(m.entityType)) {
+          return true;
+        }
+        return false;
+      });
+
+      const isFileOnly = instanceMutations.length > 0 && instanceMutations.every(m => {
+        if (m.entityType === 'template') {
+          const payload = m.payload || {};
+          const payloadKeys = Object.keys(payload);
+          // Template mutations that only touch soul/agents are file-only
+          return payloadKeys.length > 0 && payloadKeys.every(k => ['soul', 'agents'].includes(k));
+        }
+        if (m.entityType === 'agent') {
+          const payload = m.payload || {};
+          const payloadKeys = Object.keys(payload);
+          // Agent mutations that only touch soul/agentsMd/instanceId are file-only
+          return payloadKeys.length > 0 && payloadKeys.every(k => ['soul', 'agentsMd', 'instanceId'].includes(k));
+        }
+        // Any other mutation type (instance, provider, model, plugin) is NOT file-only
+        return false;
+      });
+
+      // Only add config_version change if NOT file-only
+      const instChanges: StateChange[] = isFileOnly ? [] : [
+        {
+          instanceId: inst.instanceId,
+          type: 'config' as const,
+          field: 'config_version',
+          current: null,
+          desired: currentVersion,
+          requiresRestart: true,
+        },
+      ];
 
       return {
         instanceId: inst.instanceId,

--- a/packages/control/src/services/changeset-validator.ts
+++ b/packages/control/src/services/changeset-validator.ts
@@ -266,11 +266,21 @@ function createChangesetValidator(): ChangesetValidator {
     const conflicts = [...intraConflicts, ...interConflicts];
     const hasErrors = conflicts.some(c => c.type === 'error');
 
+    // File-only changesets (no config_version bumps) are immune to staleness
+    // They only write workspace files and update DB — no config drift to worry about
+    const hasConfigVersionChange = changeset.changes.some(c => 
+      c.type === 'config' && c.field === 'config_version'
+    );
+    
     // Agent-only changesets (no config/provider/model/plugin/instance changes)
-    // are immune to staleness — they don't conflict with config version drift
+    // are also immune to staleness — they don't conflict with config version drift
     const agentOnlyTypes = new Set(['agent']);
     const isAgentOnly = changeset.changes.every(c => agentOnlyTypes.has(c.type));
-    const canApply = !hasErrors && (isAgentOnly || !staleness.stale);
+    
+    // Skip staleness check if:
+    // - No config_version change (file-only changeset)
+    // - Agent-only changeset
+    const canApply = !hasErrors && (!hasConfigVersionChange || isAgentOnly || !staleness.stale);
 
     return { conflicts, staleness, canApply };
   }


### PR DESCRIPTION
Closes #212

Template soul/agents changes are file-only — they don't need config bumps or restarts.

### Changes
**changeset-service.ts** — `preview()` detects file-only mutations (soul/agents fields only). Skips config_version change for affected instances.

**changeset-validator.ts** — staleness check skipped for changesets without config_version changes. File-only changesets can't be stale.

### Result
`armada_template_update` → changeset → approve → apply now works for soul/agents updates even when config_version is drifted from restarts.

0 TS errors, 163 tests pass.