### PR TITLE
fix: replace agent-manager.update() backdoor with updateOperational() (#216)

### DIFF
--- a/packages/control/src/routes/template-sync.ts
+++ b/packages/control/src/routes/template-sync.ts
@@ -4,6 +4,7 @@ import { templatesRepo, agentsRepo } from '../repositories/index.js';
 import { generateOpenClawConfig } from '../templates/config-generator.js';
 import { resolveVariables } from '../templates/resolver.js';
 import { registerToolDef } from '../utils/tool-registry.js';
+import { mutationService } from '../services/mutation-service.js';
 import type { NodeManager } from '../node-manager.js';
 import type { Agent, Template, TemplateSkill } from '@coderage-labs/armada-shared';
 
@@ -400,6 +401,7 @@ export function createTemplateSyncRoutes(nodeManager: NodeManager): Router {
             });
             const newId = (result as any).containerId;
             if (newId) {
+              // containerId is infrastructure state, not config — direct write OK
               agentsRepo.update(agent.id, { containerId: newId });
             }
             recreated = true;
@@ -422,12 +424,12 @@ export function createTemplateSyncRoutes(nodeManager: NodeManager): Router {
           }
         }
 
-        // 7. Update agent record
-        agentsRepo.update(agent.id, {
+        // 7. Stage configuration update mutation
+        mutationService.stage('agent', 'update', {
           role: template.role,
           skills: template.skills,
           model: template.model,
-        });
+        }, agent.id);
 
         synced.push({ name: agent.name, changes, restarted, recreated });
       }

--- a/packages/control/src/services/agent-manager.ts
+++ b/packages/control/src/services/agent-manager.ts
@@ -29,7 +29,7 @@ export interface AgentManager {
   getByName(name: string): Agent | undefined;
   getAll(): Agent[];
   getByInstance(instanceId: string): Agent[];
-  update(id: string, patch: Partial<Agent>): Agent | undefined;
+  updateOperational(id: string, patch: Pick<Partial<Agent>, 'status' | 'healthStatus' | 'lastHeartbeat' | 'heartbeatMeta' | 'avatarGenerating' | 'avatarVersion'>): Agent | undefined;
   destroy(agentName: string): Promise<import('../repositories/index.js').PendingMutation>;
 
   // Runtime
@@ -70,7 +70,7 @@ class AgentManagerImpl implements AgentManager {
     return agentsRepo.getAll().filter((a) => a.instanceId === instanceId);
   }
 
-  update(id: string, patch: Partial<Agent>): Agent | undefined {
+  updateOperational(id: string, patch: Pick<Partial<Agent>, 'status' | 'healthStatus' | 'lastHeartbeat' | 'heartbeatMeta' | 'avatarGenerating' | 'avatarVersion'>): Agent | undefined {
     return agentsRepo.update(id, patch);
   }
 
@@ -224,7 +224,7 @@ class AgentManagerImpl implements AgentManager {
     if (meta.uptimeMs !== undefined) cleanMeta.uptimeMs = meta.uptimeMs;
 
     const previousStatus = agent.status;
-    agentsRepo.update(agent.id, {
+    this.updateOperational(agent.id, {
       status: 'running',
       lastHeartbeat: new Date().toISOString(),
       healthStatus: 'healthy',


### PR DESCRIPTION
Closes #216. Generic update() replaced with updateOperational() restricted to runtime fields (status, health, heartbeat, avatar). Config updates in template-sync now use mutationService.stage(). 0 TS errors, 163 tests pass.