### PR TITLE
feat: patrol service — autonomous health monitoring and recovery (#194)

### DIFF
--- a/packages/control/src/app.ts
+++ b/packages/control/src/app.ts
@@ -56,6 +56,7 @@ import projectReposRoutes from './routes/project-repos.js';
 import { codebaseRouter } from './routes/codebase.js';
 import { learningRouter } from './routes/learning.js';
 import { analyticsRouter } from './routes/analytics.js';
+import patrolRoutes from './routes/patrol.js';
 
 export interface AppOptions {
   nodeManager: NodeManager;
@@ -123,6 +124,7 @@ export function createApp(opts: AppOptions): express.Express {
   app.use('/api/codebase', codebaseRouter);
   app.use('/api/learning', learningRouter);
   app.use('/api/analytics', analyticsRouter);
+  app.use('/api/patrol', patrolRoutes);
   app.use('/api/webhooks', webhookRoutes);
   app.use('/api/webhooks/inbound', webhooksInboundMgmtRouter);
   app.use('/api/tools', createToolRoutes(nodeManager));

--- a/packages/control/src/db/drizzle-schema.ts
+++ b/packages/control/src/db/drizzle-schema.ts
@@ -768,3 +768,19 @@ export const embeddings = sqliteTable('embeddings', {
   model: text('model').default('text-embedding-3-small'),
   createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
+
+// ── Patrol Records (#194) ────────────────────────────────────────────
+
+export const patrolRecords = sqliteTable('patrol_records', {
+  id: text('id').primaryKey(),
+  type: text('type').notNull(),
+  severity: text('severity').notNull(),
+  runId: text('run_id'),
+  stepId: text('step_id'),
+  agentId: text('agent_id'),
+  description: text('description').notNull(),
+  actionTaken: text('action_taken').notNull().default(''),
+  status: text('status').notNull().default('open'),
+  createdAt: text('created_at').notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  resolvedAt: text('resolved_at'),
+});

--- a/packages/control/src/db/migrations.ts
+++ b/packages/control/src/db/migrations.ts
@@ -636,6 +636,27 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 45,
+    description: 'Create patrol_records table for autonomous health monitoring (#194)',
+    sql: [
+      `CREATE TABLE IF NOT EXISTS patrol_records (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        run_id TEXT,
+        step_id TEXT,
+        agent_id TEXT,
+        description TEXT NOT NULL,
+        action_taken TEXT DEFAULT '',
+        status TEXT DEFAULT 'open',
+        created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        resolved_at TEXT
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_patrol_type ON patrol_records(type)',
+      'CREATE INDEX IF NOT EXISTS idx_patrol_status ON patrol_records(status)',
+    ],
+  },
 ];
 
 /**

--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -14,6 +14,7 @@ import { initDiscordBot } from './services/discord-bot.js';
 import { registerAllProviders } from './services/integrations/index.js';
 import { startVersionChecker, stopVersionChecker } from './services/version-checker.js';
 import { startStuckDetector, stopStuckDetector } from './services/stuck-detector.js';
+import { startPatrolScheduler, stopPatrolScheduler } from './services/patrol-service.js';
 import { pluginManager } from './services/plugin-manager.js';
 import { providerApiKeyRepo } from './repositories/provider-api-key-repo.js';
 
@@ -184,6 +185,9 @@ async function start() {
   // ── Stuck task detector ─────────────────────────────────────────────
   startStuckDetector();
 
+  // ── Patrol service ──────────────────────────────────────────────────
+  startPatrolScheduler(5 * 60 * 1000); // Every 5 minutes
+
   // ── Version checker ─────────────────────────────────────────────────
   startVersionChecker();
 
@@ -201,6 +205,7 @@ async function start() {
     stopHealthMonitor();
     stopWorkspaceRetention();
     stopStuckDetector();
+    stopPatrolScheduler();
     stopVersionChecker();
     stopIssueSyncScheduler();
     await stopTelegramBot();

--- a/packages/control/src/routes/patrol.ts
+++ b/packages/control/src/routes/patrol.ts
@@ -1,0 +1,95 @@
+/**
+ * Patrol API routes — list patrol records, trigger manual patrol, resolve issues (#194).
+ */
+
+import { Router } from 'express';
+import { getDrizzle } from '../db/drizzle.js';
+import { patrolRecords } from '../db/drizzle-schema.js';
+import { eq, desc } from 'drizzle-orm';
+import { runPatrol } from '../services/patrol-service.js';
+import { requireScope } from '../middleware/scopes.js';
+import { registerToolDef } from '../utils/tool-registry.js';
+
+const router = Router();
+
+// GET /api/patrol/records — list recent patrol records
+router.get('/records', requireScope('system:read'), (req, res) => {
+  const db = getDrizzle();
+  const limit = Math.min(parseInt(req.query.limit as string, 10) || 50, 200);
+  const statusFilter = req.query.status as string | undefined;
+
+  let query = db.select().from(patrolRecords).orderBy(desc(patrolRecords.createdAt)).limit(limit);
+
+  if (statusFilter) {
+    query = query.where(eq(patrolRecords.status, statusFilter)) as any;
+  }
+
+  const records = query.all();
+  res.json(records);
+});
+
+// POST /api/patrol/run — trigger manual patrol
+router.post('/run', requireScope('system:write'), (_req, res) => {
+  const records = runPatrol();
+  res.json({ ok: true, recordsCreated: records.length, records });
+});
+
+// POST /api/patrol/records/:id/resolve — mark a patrol record as resolved
+router.post('/records/:id/resolve', requireScope('system:write'), (req, res) => {
+  const db = getDrizzle();
+  const { id } = req.params;
+
+  const record = db.select().from(patrolRecords).where(eq(patrolRecords.id, id)).get();
+  if (!record) {
+    return res.status(404).json({ error: 'Patrol record not found' });
+  }
+
+  db.update(patrolRecords)
+    .set({
+      status: 'resolved',
+      resolvedAt: new Date().toISOString(),
+    })
+    .where(eq(patrolRecords.id, id))
+    .run();
+
+  res.json({ ok: true });
+});
+
+// ── Tool definitions ─────────────────────────────────────────────────
+
+registerToolDef({
+  category: 'system',
+  name: 'armada_patrol_records_list',
+  scope: 'system:read',
+  description: 'List recent patrol records from autonomous health monitoring',
+  method: 'GET',
+  path: '/api/patrol/records',
+  parameters: [
+    { name: 'limit', type: 'number', description: 'Max records to return (default 50, max 200)' },
+    { name: 'status', type: 'string', description: 'Filter by status: open or resolved' },
+  ],
+});
+
+registerToolDef({
+  category: 'system',
+  name: 'armada_patrol_run',
+  scope: 'system:write',
+  description: 'Trigger a manual patrol check',
+  method: 'POST',
+  path: '/api/patrol/run',
+  parameters: [],
+});
+
+registerToolDef({
+  category: 'system',
+  name: 'armada_patrol_record_resolve',
+  scope: 'system:write',
+  description: 'Mark a patrol record as resolved',
+  method: 'POST',
+  path: '/api/patrol/records/:id/resolve',
+  parameters: [
+    { name: 'id', type: 'string', required: true, description: 'Patrol record ID' },
+  ],
+});
+
+export default router;

--- a/packages/control/src/services/patrol-service.ts
+++ b/packages/control/src/services/patrol-service.ts
@@ -1,0 +1,419 @@
+/**
+ * Patrol service — autonomous system health monitoring and recovery (#194).
+ *
+ * Runs on a 5-minute timer, detects problems via DB queries, and takes automatic action.
+ * Each finding is stored in the patrol_records table.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDrizzle } from '../db/drizzle.js';
+import { sql } from 'drizzle-orm';
+import { workflowStepRuns, workflowRuns, agents, reviewRecords, patrolRecords } from '../db/drizzle-schema.js';
+import { eq } from 'drizzle-orm';
+import { logActivity } from './activity-service.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type PatrolRecordType =
+  | 'stuck_task'
+  | 'orphaned_run'
+  | 'rework_overflow'
+  | 'agent_offline'
+  | 'score_drop';
+
+export type PatrolSeverity = 'info' | 'warning' | 'critical';
+
+export interface PatrolRecord {
+  id: string;
+  type: PatrolRecordType;
+  severity: PatrolSeverity;
+  runId?: string;
+  stepId?: string;
+  agentId?: string;
+  description: string;
+  actionTaken: string;
+  status: 'open' | 'resolved';
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+// ── Configuration ───────────────────────────────────────────────────
+
+const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const STUCK_WARNING_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+const STUCK_CRITICAL_THRESHOLD_MS = 60 * 60 * 1000; // 60 minutes
+const AGENT_OFFLINE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+const REWORK_WARNING_COUNT = 3;
+const REWORK_CRITICAL_COUNT = 5;
+const SCORE_DROP_THRESHOLD = 1.0;
+const SCORE_WINDOW_SIZE = 10;
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+// ── Database helpers ─────────────────────────────────────────────────
+
+function storePatrolRecord(record: Omit<PatrolRecord, 'id' | 'createdAt'>): void {
+  const db = getDrizzle();
+  const id = randomUUID();
+  db.insert(patrolRecords).values({
+    id,
+    type: record.type,
+    severity: record.severity,
+    runId: record.runId,
+    stepId: record.stepId,
+    agentId: record.agentId,
+    description: record.description,
+    actionTaken: record.actionTaken,
+    status: record.status,
+    createdAt: new Date().toISOString(),
+    resolvedAt: record.resolvedAt,
+  }).run();
+}
+
+// ── Detection checks ─────────────────────────────────────────────────
+
+/**
+ * Check for stuck workflow step runs.
+ * - Warning: running >30 min
+ * - Critical: running >60 min (mark as failed)
+ */
+function checkStuckTasks(): PatrolRecord[] {
+  const db = getDrizzle();
+  const now = Date.now();
+  const records: PatrolRecord[] = [];
+
+  const runningSteps = db
+    .select()
+    .from(workflowStepRuns)
+    .where(eq(workflowStepRuns.status, 'running'))
+    .all();
+
+  for (const step of runningSteps) {
+    if (!step.startedAt) continue;
+
+    const startedTime = new Date(step.startedAt).getTime();
+    const age = now - startedTime;
+
+    if (age > STUCK_CRITICAL_THRESHOLD_MS) {
+      // Mark as failed
+      db.update(workflowStepRuns)
+        .set({ 
+          status: 'failed',
+          output: 'Auto-failed by patrol service: stuck for >60 minutes',
+          completedAt: new Date().toISOString(),
+        })
+        .where(eq(workflowStepRuns.id, step.id))
+        .run();
+
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'stuck_task',
+        severity: 'critical',
+        runId: step.runId,
+        stepId: step.stepId,
+        agentId: step.agentName || undefined,
+        description: `Step ${step.stepId} stuck for ${Math.round(age / 60000)} minutes — auto-failed`,
+        actionTaken: 'Marked step as failed',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+
+      logActivity({
+        eventType: 'patrol.stuck_task',
+        agentName: step.agentName || 'unknown',
+        detail: `Step ${step.stepId} in run ${step.runId} auto-failed after 60+ minutes`,
+      });
+    } else if (age > STUCK_WARNING_THRESHOLD_MS) {
+      // Warning only
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'stuck_task',
+        severity: 'warning',
+        runId: step.runId,
+        stepId: step.stepId,
+        agentId: step.agentName || undefined,
+        description: `Step ${step.stepId} running for ${Math.round(age / 60000)} minutes`,
+        actionTaken: 'None (monitoring)',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Check for orphaned workflow runs.
+ * - A run is orphaned if status='running' but has no running/pending/waiting_gate steps.
+ */
+function checkOrphanedRuns(): PatrolRecord[] {
+  const db = getDrizzle();
+  const records: PatrolRecord[] = [];
+
+  const runningRuns = db
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.status, 'running'))
+    .all();
+
+  for (const run of runningRuns) {
+    const activeSteps = db
+      .select()
+      .from(workflowStepRuns)
+      .where(eq(workflowStepRuns.runId, run.id))
+      .all()
+      .filter(s => ['running', 'pending', 'waiting_gate'].includes(s.status));
+
+    if (activeSteps.length === 0) {
+      // Orphaned — mark run as failed
+      db.update(workflowRuns)
+        .set({ 
+          status: 'failed',
+          completedAt: new Date().toISOString(),
+        })
+        .where(eq(workflowRuns.id, run.id))
+        .run();
+
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'orphaned_run',
+        severity: 'critical',
+        runId: run.id,
+        description: `Workflow run ${run.id} orphaned (no active steps) — auto-failed`,
+        actionTaken: 'Marked run as failed',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+
+      logActivity({
+        eventType: 'patrol.orphaned_run',
+        detail: `Workflow run ${run.id} auto-failed (orphaned)`,
+      });
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Check for rework overflow.
+ * - Warning: >3 attempts for same (run_id, step_id)
+ * - Critical: >5 attempts (fail the run)
+ */
+function checkReworkOverflow(): PatrolRecord[] {
+  const db = getDrizzle();
+  const records: PatrolRecord[] = [];
+
+  // Group by (run_id, step_id) and count
+  const reworkCounts = db.all<{ run_id: string; step_id: string; count: number }>(
+    sql`
+      SELECT run_id, step_id, COUNT(*) as count
+      FROM workflow_step_runs
+      GROUP BY run_id, step_id
+      HAVING count > ${REWORK_WARNING_COUNT}
+    `
+  );
+
+  for (const { run_id, step_id, count } of reworkCounts) {
+    if (count > REWORK_CRITICAL_COUNT) {
+      // Critical — fail the run
+      db.update(workflowRuns)
+        .set({ 
+          status: 'failed',
+          completedAt: new Date().toISOString(),
+        })
+        .where(eq(workflowRuns.id, run_id))
+        .run();
+
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'rework_overflow',
+        severity: 'critical',
+        runId: run_id,
+        stepId: step_id,
+        description: `Step ${step_id} reworked ${count} times — run auto-failed`,
+        actionTaken: 'Marked run as failed',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+
+      logActivity({
+        eventType: 'patrol.rework_overflow',
+        detail: `Run ${run_id} auto-failed after ${count} rework attempts on step ${step_id}`,
+      });
+    } else {
+      // Warning only
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'rework_overflow',
+        severity: 'warning',
+        runId: run_id,
+        stepId: step_id,
+        description: `Step ${step_id} reworked ${count} times`,
+        actionTaken: 'None (monitoring)',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Check for offline agents.
+ * - Agents with status='running' and last_heartbeat >5 min old.
+ */
+function checkAgentOffline(): PatrolRecord[] {
+  const db = getDrizzle();
+  const now = Date.now();
+  const records: PatrolRecord[] = [];
+
+  const runningAgents = db
+    .select()
+    .from(agents)
+    .where(eq(agents.status, 'running'))
+    .all();
+
+  for (const agent of runningAgents) {
+    if (!agent.lastHeartbeat) continue;
+
+    const lastHeartbeatTime = new Date(agent.lastHeartbeat).getTime();
+    const age = now - lastHeartbeatTime;
+
+    if (age > AGENT_OFFLINE_THRESHOLD_MS) {
+      // Set health to offline
+      db.update(agents)
+        .set({ healthStatus: 'offline' })
+        .where(eq(agents.id, agent.id))
+        .run();
+
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'agent_offline',
+        severity: 'warning',
+        agentId: agent.name,
+        description: `Agent ${agent.name} offline — no heartbeat for ${Math.round(age / 60000)} minutes`,
+        actionTaken: 'Set health status to offline',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+
+      logActivity({
+        eventType: 'patrol.agent_offline',
+        agentName: agent.name,
+        detail: `Agent ${agent.name} marked offline (no heartbeat for ${Math.round(age / 60000)} minutes)`,
+      });
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Check for score drops.
+ * - Compare last 10 reviews vs previous 10 for each agent.
+ * - Warning if avg score drop >1.0
+ */
+function checkScoreDrops(): PatrolRecord[] {
+  const db = getDrizzle();
+  const records: PatrolRecord[] = [];
+
+  // Get all agents with reviews
+  const agentsWithReviews = db.all<{ executor: string }>(
+    sql`SELECT DISTINCT executor FROM review_records WHERE executor IS NOT NULL`
+  );
+
+  for (const { executor } of agentsWithReviews) {
+    if (!executor) continue;
+
+    // Get all reviews for this agent, ordered by created_at desc
+    const allReviews = db
+      .select()
+      .from(reviewRecords)
+      .where(eq(reviewRecords.executor, executor))
+      .orderBy(sql`created_at DESC`)
+      .all();
+
+    if (allReviews.length < SCORE_WINDOW_SIZE * 2) continue; // Need at least 20 reviews
+
+    const last10 = allReviews.slice(0, SCORE_WINDOW_SIZE);
+    const previous10 = allReviews.slice(SCORE_WINDOW_SIZE, SCORE_WINDOW_SIZE * 2);
+
+    const avgLast = last10.reduce((sum, r) => sum + r.score, 0) / last10.length;
+    const avgPrevious = previous10.reduce((sum, r) => sum + r.score, 0) / previous10.length;
+    const drop = avgPrevious - avgLast;
+
+    if (drop > SCORE_DROP_THRESHOLD) {
+      const record: Omit<PatrolRecord, 'id' | 'createdAt'> = {
+        type: 'score_drop',
+        severity: 'warning',
+        agentId: executor,
+        description: `Agent ${executor} score dropped by ${drop.toFixed(2)} (${avgPrevious.toFixed(2)} → ${avgLast.toFixed(2)})`,
+        actionTaken: 'None (monitoring)',
+        status: 'open',
+      };
+      storePatrolRecord(record);
+      records.push({ ...record, id: '', createdAt: '' });
+
+      logActivity({
+        eventType: 'patrol.score_drop',
+        agentName: executor,
+        detail: `Score drop detected: ${drop.toFixed(2)} points`,
+      });
+    }
+  }
+
+  return records;
+}
+
+// ── Main patrol logic ────────────────────────────────────────────────
+
+export function runPatrol(): PatrolRecord[] {
+  console.log('🚔 Patrol service running checks…');
+  const allRecords: PatrolRecord[] = [];
+
+  try {
+    allRecords.push(...checkStuckTasks());
+    allRecords.push(...checkOrphanedRuns());
+    allRecords.push(...checkReworkOverflow());
+    allRecords.push(...checkAgentOffline());
+    allRecords.push(...checkScoreDrops());
+
+    if (allRecords.length > 0) {
+      console.log(`🚨 Patrol found ${allRecords.length} issue(s)`);
+    } else {
+      console.log('✅ Patrol completed — no issues detected');
+    }
+  } catch (err: unknown) {
+    console.error('Patrol service error:', err);
+  }
+
+  return allRecords;
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+export function startPatrolScheduler(intervalMs: number = CHECK_INTERVAL_MS): void {
+  if (intervalHandle) {
+    console.warn('Patrol scheduler already running');
+    return;
+  }
+
+  console.log(`🚔 Patrol scheduler started (checking every ${intervalMs / 1000}s)`);
+  intervalHandle = setInterval(() => {
+    runPatrol();
+  }, intervalMs);
+
+  // Run once immediately
+  runPatrol();
+}
+
+export function stopPatrolScheduler(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+    console.log('🚔 Patrol scheduler stopped');
+  }
+}


### PR DESCRIPTION
Closes #194

### New: Patrol Service
5-minute timer, DB-only detection, automatic recovery. No LLM cost.

**Detection checks:**
- Stuck tasks (>30min warn, >60min auto-fail)
- Orphaned runs (running with no active steps → fail)
- Rework overflow (>3 warn, >5 fail run)
- Agent offline (no heartbeat >5min → mark offline)
- Score drops (avg score dropped >1.0 in recent reviews)

**API:**
- `GET /api/patrol/records` — list findings
- `POST /api/patrol/run` — trigger manual check
- `POST /api/patrol/records/:id/resolve` — mark resolved

**Integration:**
- Scheduler starts on server boot
- Migration v45: patrol_records table
- All findings stored for audit trail

558 lines, 0 TS errors, 163 tests pass.